### PR TITLE
fix: pass through Claude effort

### DIFF
--- a/.changeset/claude-effort-passthrough.md
+++ b/.changeset/claude-effort-passthrough.md
@@ -1,0 +1,5 @@
+---
+"opencode-anthropic-multi-account": patch
+---
+
+Pass through client Claude Code output effort when provided instead of always forcing high, with environment overrides for pinned effort values.

--- a/packages/anthropic-multi-account/README.md
+++ b/packages/anthropic-multi-account/README.md
@@ -47,6 +47,17 @@ Claude tool handling is OpenCode-first:
 
 This is an internal compatibility policy, not a third user-facing mode.
 
+## Claude Code effort
+
+For non-Haiku Claude Code requests, the plugin forwards a client-provided effort
+from `output_config.effort`, `reasoning.effort`, `reasoning_effort`, or
+`reasoningEffort`. If the client does not provide one, it falls back to `high`.
+
+Operators can pin the outbound effort with `CLAUDE_MULTI_ACCOUNT_EFFORT` or
+`ANTHROPIC_MULTI_ACCOUNT_EFFORT`. Supported values are `low`, `medium`, `high`,
+`xhigh`, `max`, `ultracode`, and `client`; `ultracode` is normalized to `xhigh`
+on the wire.
+
 ## Server Mode migration
 
 ```bash

--- a/packages/anthropic-multi-account/src/request/upstream-request.ts
+++ b/packages/anthropic-multi-account/src/request/upstream-request.ts
@@ -21,13 +21,17 @@ import { selectOpenCodeNativeTools, type ToolDefinition } from "./tool-adapter";
 const BILLING_SEED = "59cf53e54c78";
 const SESSION_IDLE_ROTATE_MS = 15 * 60 * 1000;
 const DEFAULT_CONTEXT_MANAGEMENT = {};
-const DEFAULT_OUTPUT_CONFIG = { effort: "high" };
+const DEFAULT_OUTPUT_EFFORT = "high";
+const VALID_OUTPUT_EFFORT_VALUES = new Set(["low", "medium", "high", "xhigh", "ultracode", "max", "client"]);
+
+type OutputEffortValue = "low" | "medium" | "high" | "xhigh" | "ultracode" | "max" | "client";
 
 type ReverseLookup = Map<string, string> | Record<string, string> | undefined;
 
 interface UpstreamRequestTestOverrides {
   now?: () => number;
   createSessionId?: () => string;
+  outputEffort?: OutputEffortValue;
 }
 
 let upstreamRequestTestOverrides: UpstreamRequestTestOverrides = {};
@@ -59,6 +63,56 @@ export function getUpstreamSessionId(): string {
 
 function isRecord(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null;
+}
+
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readOutputEffortValue(value: unknown): OutputEffortValue | undefined {
+  const normalized = readString(value)?.toLowerCase();
+  return normalized && VALID_OUTPUT_EFFORT_VALUES.has(normalized)
+    ? normalized as OutputEffortValue
+    : undefined;
+}
+
+function normalizeEffortForWire(effort: OutputEffortValue): string {
+  return effort === "ultracode" ? "xhigh" : effort;
+}
+
+function getConfiguredOutputEffort(): OutputEffortValue | undefined {
+  return upstreamRequestTestOverrides.outputEffort
+    ?? readOutputEffortValue(process.env.CLAUDE_MULTI_ACCOUNT_EFFORT)
+    ?? readOutputEffortValue(process.env.ANTHROPIC_MULTI_ACCOUNT_EFFORT);
+}
+
+function getClientOutputEffort(inputBody: Record<string, unknown>): OutputEffortValue | undefined {
+  const outputConfig = isRecord(inputBody.output_config) ? inputBody.output_config : undefined;
+  const reasoning = isRecord(inputBody.reasoning) ? inputBody.reasoning : undefined;
+  const thinking = isRecord(inputBody.thinking) ? inputBody.thinking : undefined;
+
+  return readOutputEffortValue(outputConfig?.effort)
+    ?? readOutputEffortValue(reasoning?.effort)
+    ?? readOutputEffortValue(inputBody.reasoning_effort)
+    ?? readOutputEffortValue(inputBody.reasoningEffort)
+    ?? readOutputEffortValue(thinking?.effort);
+}
+
+export function resolveOutputEffort(
+  inputBody: Record<string, unknown>,
+  configuredEffort = getConfiguredOutputEffort(),
+): string {
+  if (configuredEffort && configuredEffort !== "client") {
+    return normalizeEffortForWire(configuredEffort);
+  }
+
+  const clientEffort = getClientOutputEffort(inputBody);
+  return normalizeEffortForWire(clientEffort ?? DEFAULT_OUTPUT_EFFORT);
+}
+
+function isHaikuModel(modelId: string): boolean {
+  return modelId.trim().toLowerCase().includes("haiku");
 }
 
 function collectToolUseIds(message: Message): string[] {
@@ -240,7 +294,9 @@ export function buildUpstreamRequest(
   if (supportsAdaptiveThinking(modelId)) {
     body.thinking = { type: "adaptive" };
     body.context_management = DEFAULT_CONTEXT_MANAGEMENT;
-    body.output_config = DEFAULT_OUTPUT_CONFIG;
+  }
+  if (modelId && !isHaikuModel(modelId)) {
+    body.output_config = { effort: resolveOutputEffort(inputBody) };
   }
   body.max_tokens = resolveMaxTokens(body.max_tokens);
 

--- a/packages/anthropic-multi-account/tests/request/upstream-request.test.ts
+++ b/packages/anthropic-multi-account/tests/request/upstream-request.test.ts
@@ -205,7 +205,7 @@ describe("upstream-request", () => {
     expect(result.max_tokens).toBe(32_000);
     expect("thinking" in result).toBe(false);
     expect("context_management" in result).toBe(false);
-    expect("output_config" in result).toBe(false);
+    expect(result.output_config).toEqual({ effort: "high" });
     expect(result.tools).toEqual([{ name: "OriginalTool", description: "legacy" }]);
     expect(messages).toHaveLength(3);
     expect(messages[1]?.content).toEqual([{ type: "text", text: "Working on it" }]);
@@ -324,6 +324,62 @@ describe("upstream-request", () => {
     expect("top_k" in result).toBe(false);
     expect(result.thinking).toEqual({ type: "adaptive" });
     expect(result.output_config).toEqual({ effort: "high" });
+  });
+
+  test("buildUpstreamRequest passes through client output_config effort on non-Haiku models", () => {
+    const result = buildUpstreamRequest({
+      model: "claude-sonnet-4-6",
+      output_config: { effort: "low" },
+      messages: [{ role: "user", content: "hello" }],
+    }, createIdentity(), createTemplate());
+
+    expect(result.thinking).toEqual({ type: "adaptive" });
+    expect(result.output_config).toEqual({ effort: "low" });
+  });
+
+  test("buildUpstreamRequest maps Responses reasoning effort into output_config effort", () => {
+    const result = buildUpstreamRequest({
+      model: "claude-sonnet-4-6",
+      reasoning: { effort: "medium" },
+      messages: [{ role: "user", content: "hello" }],
+    }, createIdentity(), createTemplate());
+
+    expect(result.output_config).toEqual({ effort: "medium" });
+  });
+
+  test("buildUpstreamRequest lets configured effort override client effort", () => {
+    setUpstreamRequestTestOverridesForTest({ outputEffort: "xhigh" });
+
+    const result = buildUpstreamRequest({
+      model: "claude-sonnet-4-6",
+      output_config: { effort: "low" },
+      messages: [{ role: "user", content: "hello" }],
+    }, createIdentity(), createTemplate());
+
+    expect(result.output_config).toEqual({ effort: "xhigh" });
+  });
+
+  test("buildUpstreamRequest normalizes ultracode effort to xhigh on the wire", () => {
+    setUpstreamRequestTestOverridesForTest({ outputEffort: "ultracode" });
+
+    const result = buildUpstreamRequest({
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "hello" }],
+    }, createIdentity(), createTemplate());
+
+    expect(result.output_config).toEqual({ effort: "xhigh" });
+  });
+
+  test("buildUpstreamRequest emits output_config for non-adaptive non-Haiku models", () => {
+    const result = buildUpstreamRequest({
+      model: "claude-sonnet-4-5",
+      output_config: { effort: "max" },
+      messages: [{ role: "user", content: "hello" }],
+    }, createIdentity(), createTemplate());
+
+    expect("thinking" in result).toBe(false);
+    expect("context_management" in result).toBe(false);
+    expect(result.output_config).toEqual({ effort: "max" });
   });
 
   test("buildUpstreamRequest drops incoming thinking controls and does not force adaptive on Haiku", () => {

--- a/packages/gateway/src/codex-claude-bridge.ts
+++ b/packages/gateway/src/codex-claude-bridge.ts
@@ -24,6 +24,7 @@ interface AnthropicMessageBody {
   messages: Array<Record<string, unknown>>;
   metadata?: Record<string, unknown>;
   model: string;
+  output_config?: { effort: string };
   stream: boolean;
   system?: string | Array<Record<string, unknown>>;
   tool_choice?: Record<string, unknown>;
@@ -282,8 +283,17 @@ function convertCodexResponsesBodyToAnthropicMessages(body: Record<string, unkno
   if (toolChoice) result.tool_choice = toolChoice;
   const metadata = readRecord(body.metadata);
   if (metadata) result.metadata = metadata;
+  const effort = readReasoningEffort(body);
+  if (effort) result.output_config = { effort };
 
   return { ok: true, body: result };
+}
+
+function readReasoningEffort(body: Record<string, unknown>): string | undefined {
+  const reasoning = readRecord(body.reasoning);
+  return readString(reasoning?.effort) ??
+    readString(body.reasoning_effort) ??
+    readString(body.reasoningEffort);
 }
 
 function readCodexWebSocketResponseBody(message: GatewayWebSocketMessage): Record<string, unknown> | undefined {

--- a/packages/gateway/tests/routing.test.ts
+++ b/packages/gateway/tests/routing.test.ts
@@ -888,6 +888,7 @@ describe("gateway routing", () => {
         body: JSON.stringify({
           model: "kyoli-claude/claude-sonnet-4-5",
           instructions: "stay brief",
+          reasoning: { effort: "low" },
           input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
           tools: [{ type: "function", name: "shell", parameters: { type: "object" } }],
         }),
@@ -902,6 +903,7 @@ describe("gateway routing", () => {
     expect(seenContext?.body).toMatchObject({
       model: "claude-code/claude-sonnet-4-5",
       stream: true,
+      output_config: { effort: "low" },
       system: "stay brief",
       messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
       tools: [{ name: "shell", input_schema: { type: "object" } }],


### PR DESCRIPTION
## Summary\n- pass through client Claude effort from output_config/reasoning fields instead of always forcing high\n- add env overrides for pinned Claude effort values, including ultracode -> xhigh normalization\n- forward Codex Responses reasoning.effort through the kyoli-claude bridge\n\n## Validation\n- pnpm --filter opencode-anthropic-multi-account exec vitest run tests/request/upstream-request.test.ts tests/contract/native-contract-invariants.test.ts\n- pnpm --filter @kyoli-gam/gateway exec vitest run tests/routing.test.ts\n- pnpm --filter opencode-anthropic-multi-account typecheck\n- pnpm --filter @kyoli-gam/gateway typecheck\n- pnpm --filter opencode-anthropic-multi-account test:contract:native\n- pnpm --filter @kyoli-gam/gateway test\n- pnpm --filter opencode-anthropic-multi-account build\n- pnpm --filter @kyoli-gam/gateway build\n- git diff --check