### PR TITLE
fix: map OpenCode thinking budget to Claude effort

### DIFF
--- a/.changeset/opencode-thinking-budget-effort.md
+++ b/.changeset/opencode-thinking-budget-effort.md
@@ -1,0 +1,5 @@
+---
+"opencode-anthropic-multi-account": patch
+---
+
+Map OpenCode Anthropic thinking budgets into Claude Code output effort so variant-selected reasoning levels are preserved.

--- a/packages/anthropic-multi-account/README.md
+++ b/packages/anthropic-multi-account/README.md
@@ -51,7 +51,9 @@ This is an internal compatibility policy, not a third user-facing mode.
 
 For non-Haiku Claude Code requests, the plugin forwards a client-provided effort
 from `output_config.effort`, `reasoning.effort`, `reasoning_effort`, or
-`reasoningEffort`. If the client does not provide one, it falls back to `high`.
+`reasoningEffort`. It also maps OpenCode/Anthropic `thinking.budgetTokens`
+or Anthropic wire `thinking.budget_tokens` into an output effort. If the client
+does not provide one, it falls back to `high`.
 
 Operators can pin the outbound effort with `CLAUDE_MULTI_ACCOUNT_EFFORT` or
 `ANTHROPIC_MULTI_ACCOUNT_EFFORT`. Supported values are `low`, `medium`, `high`,

--- a/packages/anthropic-multi-account/src/request/upstream-request.ts
+++ b/packages/anthropic-multi-account/src/request/upstream-request.ts
@@ -81,6 +81,19 @@ function normalizeEffortForWire(effort: OutputEffortValue): string {
   return effort === "ultracode" ? "xhigh" : effort;
 }
 
+function readPositiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function effortFromThinkingBudget(thinking: JsonRecord | undefined): OutputEffortValue | undefined {
+  const budgetTokens = readPositiveNumber(thinking?.budget_tokens) ?? readPositiveNumber(thinking?.budgetTokens);
+  if (budgetTokens === undefined) return undefined;
+  if (budgetTokens >= 32_000) return "max";
+  if (budgetTokens >= 16_000) return "high";
+  if (budgetTokens >= 8_000) return "medium";
+  return "low";
+}
+
 function getConfiguredOutputEffort(): OutputEffortValue | undefined {
   return upstreamRequestTestOverrides.outputEffort
     ?? readOutputEffortValue(process.env.CLAUDE_MULTI_ACCOUNT_EFFORT)
@@ -96,7 +109,8 @@ function getClientOutputEffort(inputBody: Record<string, unknown>): OutputEffort
     ?? readOutputEffortValue(reasoning?.effort)
     ?? readOutputEffortValue(inputBody.reasoning_effort)
     ?? readOutputEffortValue(inputBody.reasoningEffort)
-    ?? readOutputEffortValue(thinking?.effort);
+    ?? readOutputEffortValue(thinking?.effort)
+    ?? effortFromThinkingBudget(thinking);
 }
 
 export function resolveOutputEffort(

--- a/packages/anthropic-multi-account/tests/request/upstream-request.test.ts
+++ b/packages/anthropic-multi-account/tests/request/upstream-request.test.ts
@@ -347,6 +347,27 @@ describe("upstream-request", () => {
     expect(result.output_config).toEqual({ effort: "medium" });
   });
 
+  test("buildUpstreamRequest maps OpenCode Anthropic thinking budgetTokens into output_config effort", () => {
+    const result = buildUpstreamRequest({
+      model: "claude-sonnet-4-6",
+      thinking: { type: "enabled", budgetTokens: 16_000 },
+      messages: [{ role: "user", content: "hello" }],
+    }, createIdentity(), createTemplate());
+
+    expect(result.thinking).toEqual({ type: "adaptive" });
+    expect(result.output_config).toEqual({ effort: "high" });
+  });
+
+  test("buildUpstreamRequest maps Anthropic snake_case thinking budget into max output effort", () => {
+    const result = buildUpstreamRequest({
+      model: "claude-sonnet-4-6",
+      thinking: { type: "enabled", budget_tokens: 64_000 },
+      messages: [{ role: "user", content: "hello" }],
+    }, createIdentity(), createTemplate());
+
+    expect(result.output_config).toEqual({ effort: "max" });
+  });
+
   test("buildUpstreamRequest lets configured effort override client effort", () => {
     setUpstreamRequestTestOverridesForTest({ outputEffort: "xhigh" });
 


### PR DESCRIPTION
## Summary\n- map OpenCode/Anthropic thinking.budgetTokens and thinking.budget_tokens into Claude Code output_config.effort\n- preserve explicit output_config/reasoning effort precedence\n- document the OpenCode Anthropic budget mapping\n\n## Validation\n- pnpm --filter opencode-anthropic-multi-account exec vitest run tests/request/upstream-request.test.ts tests/contract/native-contract-invariants.test.ts\n- pnpm --filter opencode-anthropic-multi-account typecheck\n- pnpm --filter opencode-anthropic-multi-account build\n- git diff --check