### PR TITLE
fix(opencode): pass variant effort through provider

### DIFF
--- a/packages/anthropic-multi-account/src/index.ts
+++ b/packages/anthropic-multi-account/src/index.ts
@@ -26,7 +26,13 @@ import {
   getStaticHeaders,
   orderHeadersForOutbound,
 } from "./request/headers";
-import { getUpstreamSessionId } from "./request/upstream-request";
+import {
+  getClientOutputEffort,
+  getUpstreamSessionId,
+  OPENCODE_OUTPUT_EFFORT_HEADER,
+  readOpenCodeVariantEffort,
+  type OutputEffortValue,
+} from "./request/upstream-request";
 import { syncBootstrapAuth } from "./oauth/bootstrap";
 import { sanitizeError } from "./shared/error-utils";
 import { getSessionId, startHeartbeat } from "./session-heartbeat";
@@ -80,6 +86,18 @@ function applyOrderedHeaders(
     : orderedHeaders;
 }
 
+function getMessageVariant(input: { message?: { model?: Record<string, unknown> } }): unknown {
+  return input.message?.model?.variant;
+}
+
+function isAnthropicChatHook(input: {
+  provider?: { info?: { id?: string } };
+  model?: { providerID?: string };
+}): boolean {
+  return input.provider?.info?.id === ANTHROPIC_OAUTH_ADAPTER.authProviderId
+    || input.model?.providerID === ANTHROPIC_OAUTH_ADAPTER.authProviderId;
+}
+
 export const ClaudeMultiAuthPlugin: Plugin = async (ctx) => {
   if (process.env.CLAUDE_MULTI_ACCOUNT_TRACE_PLUGIN === "1") {
     console.error("[anthropic-multi-account] plugin function called");
@@ -99,6 +117,7 @@ export const ClaudeMultiAuthPlugin: Plugin = async (ctx) => {
   let heartbeatHandle: { stop(): void } | null = null;
   let heartbeatToken: string | null = null;
   let heartbeatSessionId: string | null = null;
+  const outputEffortBySession = new Map<string, OutputEffortValue>();
 
   const stopHeartbeat = (): void => {
     heartbeatHandle?.stop();
@@ -345,7 +364,47 @@ export const ClaudeMultiAuthPlugin: Plugin = async (ctx) => {
 
   await lifecycle.load({ type: "api" }).catch(() => {});
 
-  return {
+  const hooks = {
+    "chat.params": async (
+      input: {
+        sessionID: string;
+        provider?: { info?: { id?: string } };
+        model?: { providerID?: string };
+        message?: { model?: Record<string, unknown> };
+      },
+      output: { options: Record<string, unknown> },
+    ): Promise<void> => {
+      if (!isAnthropicChatHook(input)) return;
+
+      const outputEffort = getClientOutputEffort(output.options)
+        ?? readOpenCodeVariantEffort(getMessageVariant(input));
+
+      if (!outputEffort || outputEffort === "client") {
+        outputEffortBySession.delete(input.sessionID);
+        return;
+      }
+
+      outputEffortBySession.set(input.sessionID, outputEffort);
+    },
+
+    "chat.headers": async (
+      input: {
+        sessionID: string;
+        provider?: { info?: { id?: string } };
+        model?: { providerID?: string };
+        message?: { model?: Record<string, unknown> };
+      },
+      output: { headers: Record<string, string> },
+    ): Promise<void> => {
+      if (!isAnthropicChatHook(input)) return;
+
+      const outputEffort = outputEffortBySession.get(input.sessionID)
+        ?? readOpenCodeVariantEffort(getMessageVariant(input));
+      if (!outputEffort || outputEffort === "client") return;
+
+      output.headers[OPENCODE_OUTPUT_EFFORT_HEADER] = outputEffort;
+    },
+
     "experimental.chat.system.transform": async (
       input: Record<string, unknown>,
       output: { system?: string[] },
@@ -368,4 +427,5 @@ export const ClaudeMultiAuthPlugin: Plugin = async (ctx) => {
       loader: authLoader,
     },
   };
+  return hooks;
 };

--- a/packages/anthropic-multi-account/src/request/upstream-request.ts
+++ b/packages/anthropic-multi-account/src/request/upstream-request.ts
@@ -24,7 +24,9 @@ const DEFAULT_CONTEXT_MANAGEMENT = {};
 const DEFAULT_OUTPUT_EFFORT = "high";
 const VALID_OUTPUT_EFFORT_VALUES = new Set(["low", "medium", "high", "xhigh", "ultracode", "max", "client"]);
 
-type OutputEffortValue = "low" | "medium" | "high" | "xhigh" | "ultracode" | "max" | "client";
+export const OPENCODE_OUTPUT_EFFORT_HEADER = "x-kyoli-opencode-effort";
+
+export type OutputEffortValue = "low" | "medium" | "high" | "xhigh" | "ultracode" | "max" | "client";
 
 type ReverseLookup = Map<string, string> | Record<string, string> | undefined;
 
@@ -70,11 +72,17 @@ function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }
 
-function readOutputEffortValue(value: unknown): OutputEffortValue | undefined {
+export function readOutputEffortValue(value: unknown): OutputEffortValue | undefined {
   const normalized = readString(value)?.toLowerCase();
   return normalized && VALID_OUTPUT_EFFORT_VALUES.has(normalized)
     ? normalized as OutputEffortValue
     : undefined;
+}
+
+export function readOpenCodeVariantEffort(value: unknown): OutputEffortValue | undefined {
+  const normalized = readString(value)?.toLowerCase();
+  if (normalized === "minimal") return "low";
+  return readOutputEffortValue(normalized);
 }
 
 function normalizeEffortForWire(effort: OutputEffortValue): string {
@@ -88,7 +96,7 @@ function readPositiveNumber(value: unknown): number | undefined {
 function effortFromThinkingBudget(thinking: JsonRecord | undefined): OutputEffortValue | undefined {
   const budgetTokens = readPositiveNumber(thinking?.budget_tokens) ?? readPositiveNumber(thinking?.budgetTokens);
   if (budgetTokens === undefined) return undefined;
-  if (budgetTokens >= 32_000) return "max";
+  if (budgetTokens >= 31_999) return "max";
   if (budgetTokens >= 16_000) return "high";
   if (budgetTokens >= 8_000) return "medium";
   return "low";
@@ -100,12 +108,13 @@ function getConfiguredOutputEffort(): OutputEffortValue | undefined {
     ?? readOutputEffortValue(process.env.ANTHROPIC_MULTI_ACCOUNT_EFFORT);
 }
 
-function getClientOutputEffort(inputBody: Record<string, unknown>): OutputEffortValue | undefined {
+export function getClientOutputEffort(inputBody: Record<string, unknown>): OutputEffortValue | undefined {
   const outputConfig = isRecord(inputBody.output_config) ? inputBody.output_config : undefined;
   const reasoning = isRecord(inputBody.reasoning) ? inputBody.reasoning : undefined;
   const thinking = isRecord(inputBody.thinking) ? inputBody.thinking : undefined;
 
   return readOutputEffortValue(outputConfig?.effort)
+    ?? readOutputEffortValue(inputBody.effort)
     ?? readOutputEffortValue(reasoning?.effort)
     ?? readOutputEffortValue(inputBody.reasoning_effort)
     ?? readOutputEffortValue(inputBody.reasoningEffort)
@@ -294,10 +303,11 @@ export function buildUpstreamRequest(
   inputBody: Record<string, unknown>,
   identity: ClaudeIdentity,
   template: TemplateData,
-  options?: { sessionId?: string },
+  options?: { sessionId?: string; outputEffort?: OutputEffortValue },
 ): Record<string, unknown> {
   const { body, firstUserMessage, systemTexts } = normalizeAnthropicClientRequest(inputBody);
   const activeSessionId = options?.sessionId ?? getActiveSessionId();
+  const configuredEffort = getConfiguredOutputEffort() ?? options?.outputEffort;
 
   const incomingTools = Array.isArray(body.tools) ? body.tools as ToolDefinition[] : [];
   body.tools = selectOpenCodeNativeTools({
@@ -310,7 +320,7 @@ export function buildUpstreamRequest(
     body.context_management = DEFAULT_CONTEXT_MANAGEMENT;
   }
   if (modelId && !isHaikuModel(modelId)) {
-    body.output_config = { effort: resolveOutputEffort(inputBody) };
+    body.output_config = { effort: resolveOutputEffort(inputBody, configuredEffort) };
   }
   body.max_tokens = resolveMaxTokens(body.max_tokens);
 

--- a/packages/anthropic-multi-account/src/runtime/factory.ts
+++ b/packages/anthropic-multi-account/src/runtime/factory.ts
@@ -29,8 +29,11 @@ import {
   buildUpstreamRequest,
   createStreamingReverseMapper,
   getDanglingToolUseError,
+  OPENCODE_OUTPUT_EFFORT_HEADER,
+  readOpenCodeVariantEffort,
   getUpstreamSessionId,
   reverseMapResponse,
+  type OutputEffortValue,
 } from "../request/upstream-request";
 import { claudeCodeIntegration, type ClaudeIdentity } from "../claude-code";
 import type { PluginClient, StoredAccount } from "../shared/types";
@@ -95,6 +98,10 @@ function extractIncomingHeaders(
 
 function isRecord(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null;
+}
+
+function readHeaderOutputEffort(headers: Record<string, string>): OutputEffortValue | undefined {
+  return readOpenCodeVariantEffort(headers[OPENCODE_OUTPUT_EFFORT_HEADER]);
 }
 
 function messageHasToolUse(message: Message): boolean {
@@ -163,6 +170,7 @@ function transformBodyToUpstream(
   body: string,
   identity: ClaudeIdentity,
   sessionId: string,
+  outputEffort?: OutputEffortValue,
 ): { body: string; reverseLookup: Map<string, string>; validationError: string | null } {
   try {
     const parsed = JSON.parse(body) as unknown;
@@ -176,7 +184,7 @@ function transformBodyToUpstream(
       parsed as Record<string, unknown>,
       identity,
       template,
-      { sessionId },
+      { sessionId, outputEffort },
     );
 
     const validationError = getDanglingToolUseError(
@@ -381,6 +389,8 @@ export class AccountRuntimeFactory {
 
     const incomingHeaders = extractIncomingHeaders(transformedInput, init);
     const sessionId = incomingHeaders["x-claude-code-session-id"] ?? getUpstreamSessionId();
+    const outputEffort = readHeaderOutputEffort(incomingHeaders);
+    delete incomingHeaders[OPENCODE_OUTPUT_EFFORT_HEADER];
     const headers = this.buildOutboundHeaders(
       incomingHeaders,
       sessionId,
@@ -394,7 +404,7 @@ export class AccountRuntimeFactory {
     }
 
     const transformedRequest = typeof init?.body === "string"
-      ? transformBodyToUpstream(init.body, identity, sessionId)
+      ? transformBodyToUpstream(init.body, identity, sessionId, outputEffort)
       : { body: init?.body, reverseLookup: new Map<string, string>(), validationError: null };
 
     if (transformedRequest.validationError) {

--- a/packages/anthropic-multi-account/tests/index.test.ts
+++ b/packages/anthropic-multi-account/tests/index.test.ts
@@ -115,6 +115,47 @@ describe("index", () => {
     ]);
   });
 
+  test("bridges OpenCode message variant into an internal effort header", async () => {
+    const plugin = await ClaudeMultiAuthPlugin({ client: createMockClient() } as any);
+    const chatHeaders = plugin["chat.headers"] as (
+      input: unknown,
+      output: { headers: Record<string, string> },
+    ) => Promise<void>;
+    const output = { headers: {} as Record<string, string> };
+
+    await chatHeaders({
+      provider: { info: { id: "anthropic" } },
+      model: { providerID: "anthropic" },
+      message: { model: { variant: "max" } },
+    }, output);
+
+    expect(output.headers["x-kyoli-opencode-effort"]).toBe("max");
+  });
+
+  test("bridges OpenCode resolved chat params into an internal effort header", async () => {
+    const plugin = await ClaudeMultiAuthPlugin({ client: createMockClient() } as any);
+    const chatParams = plugin["chat.params"] as (
+      input: unknown,
+      output: { options: Record<string, unknown> },
+    ) => Promise<void>;
+    const chatHeaders = plugin["chat.headers"] as (
+      input: unknown,
+      output: { headers: Record<string, string> },
+    ) => Promise<void>;
+    const input = {
+      sessionID: "session-params",
+      provider: { info: { id: "anthropic" } },
+      model: { providerID: "anthropic" },
+      message: { model: { variant: "max" } },
+    };
+    const output = { headers: {} as Record<string, string> };
+
+    await chatParams(input, { options: { effort: "medium" } });
+    await chatHeaders(input, output);
+
+    expect(output.headers["x-kyoli-opencode-effort"]).toBe("medium");
+  });
+
   test("plugin loads in a temporary OpenCode config dir without user config", async () => {
     const { dir, cleanup } = await setupTestEnv();
 

--- a/packages/anthropic-multi-account/tests/request/upstream-request.test.ts
+++ b/packages/anthropic-multi-account/tests/request/upstream-request.test.ts
@@ -380,6 +380,35 @@ describe("upstream-request", () => {
     expect(result.output_config).toEqual({ effort: "xhigh" });
   });
 
+  test("buildUpstreamRequest uses explicit OpenCode variant effort when body has no effort", () => {
+    const result = buildUpstreamRequest({
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "hello" }],
+    }, createIdentity(), createTemplate(), { outputEffort: "max" });
+
+    expect(result.output_config).toEqual({ effort: "max" });
+  });
+
+  test("buildUpstreamRequest reads OpenCode top-level effort option", () => {
+    const result = buildUpstreamRequest({
+      model: "claude-sonnet-4-6",
+      effort: "medium",
+      messages: [{ role: "user", content: "hello" }],
+    }, createIdentity(), createTemplate());
+
+    expect(result.output_config).toEqual({ effort: "medium" });
+  });
+
+  test("buildUpstreamRequest maps OpenCode max thinking budget into max output effort", () => {
+    const result = buildUpstreamRequest({
+      model: "claude-sonnet-4-6",
+      thinking: { type: "enabled", budgetTokens: 31_999 },
+      messages: [{ role: "user", content: "hello" }],
+    }, createIdentity(), createTemplate());
+
+    expect(result.output_config).toEqual({ effort: "max" });
+  });
+
   test("buildUpstreamRequest normalizes ultracode effort to xhigh on the wire", () => {
     setUpstreamRequestTestOverridesForTest({ outputEffort: "ultracode" });
 

--- a/packages/anthropic-multi-account/tests/runtime/factory.test.ts
+++ b/packages/anthropic-multi-account/tests/runtime/factory.test.ts
@@ -111,6 +111,34 @@ describe("runtime-factory", () => {
     expect(body.tools[0]?.name).toMatch(/^tool_[a-f0-9]+$/);
   });
 
+  test("uses OpenCode variant effort bridge header without forwarding it upstream", async () => {
+    const uuid = await seedAccount();
+    const factory = new AccountRuntimeFactory(store, client);
+    const runtime = await factory.getRuntime(uuid);
+
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response("ok"));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await runtime.fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-kyoli-opencode-effort": "max",
+      },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const headers = toHeaders(init?.headers);
+    const body = JSON.parse(String(init?.body)) as { output_config?: { effort?: string } };
+
+    expect(headers.has("x-kyoli-opencode-effort")).toBe(false);
+    expect(body.output_config).toEqual({ effort: "max" });
+  });
+
   test("prefers stored per-account Claude identity over process identity", async () => {
     const uuid = await seedAccount({
       accountId: "provider-account",


### PR DESCRIPTION
## Summary
- bridge OpenCode `--variant` / resolved chat params effort into the Anthropic multi-account provider request
- pass the selected effort through an internal plugin header and strip it before the upstream Anthropic-compatible request
- add regression coverage for explicit variant effort, top-level OpenCode `effort`, OpenCode `minimal -> low`, and `max` budget `31999`

## Root cause
OpenCode exposes bare `--variant` through the plugin hook inputs and resolves Anthropic variant options before provider request construction, but the multi-account provider transform rebuilt the upstream request without carrying that selected effort. The provider therefore fell back to the hardcoded default `high` unless the request body already contained a recognized effort shape.

## Architecture
The plugin now uses `chat.params` as the primary source of truth because that hook sees OpenCode's resolved provider options. It stores the effort by session, then `chat.headers` forwards it to the runtime via `x-kyoli-opencode-effort`. The runtime consumes and deletes that internal header before building outbound headers, so it cannot leak upstream. `buildUpstreamRequest` receives the selected effort explicitly and emits it as `output_config.effort`.

## Validation
- `pnpm --filter opencode-anthropic-multi-account exec vitest run tests/index.test.ts tests/request/upstream-request.test.ts tests/runtime/factory.test.ts`
- `pnpm --filter opencode-anthropic-multi-account typecheck`
- `pnpm --filter opencode-anthropic-multi-account build`
- `pnpm --filter opencode-anthropic-multi-account test:contract:native`
- OpenCode 1.15.12 local e2e with local built plugin:
  - `--variant low` -> upstream `output_config.effort: low`
  - `--variant medium` -> upstream `output_config.effort: medium`
  - `--variant high` -> upstream `output_config.effort: high`
  - `--variant max` -> upstream `output_config.effort: max`
  - `--variant minimal` -> upstream `output_config.effort: low`
  - internal `x-kyoli-opencode-effort` header did not leak upstream in all e2e cases
