### PR TITLE
fix(claude-code): refresh 2.1.159 compatibility

### DIFF
--- a/.changeset/claude-code-2159.md
+++ b/.changeset/claude-code-2159.md
@@ -1,0 +1,5 @@
+---
+"opencode-anthropic-multi-account": patch
+---
+
+Refresh Claude Code compatibility metadata for `@anthropic-ai/claude-code@2.1.159` after local binary, template, wire, and native contract validation.

--- a/packages/anthropic-multi-account/src/claude-code/fingerprint/capture.ts
+++ b/packages/anthropic-multi-account/src/claude-code/fingerprint/capture.ts
@@ -35,7 +35,7 @@ const STATIC_HEADER_NAMES = [
 ] as const;
 const SUPPORTED_CC_RANGE = {
   min: "1.0.0",
-  maxTested: "2.1.158",
+  maxTested: "2.1.159",
 } as const;
 
 type TemplateSource = "bundled" | "cached" | "live";

--- a/packages/anthropic-multi-account/src/claude-code/fingerprint/data.json
+++ b/packages/anthropic-multi-account/src/claude-code/fingerprint/data.json
@@ -1052,7 +1052,7 @@
     "Write"
   ],
   "anthropic_beta": "claude-code-20250219,oauth-2025-04-20,context-1m-2025-08-07,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,extended-cache-ttl-2025-04-11",
-  "cc_version": "2.1.158",
+  "cc_version": "2.1.159",
   "header_order": [
     "Accept",
     "Authorization",
@@ -1082,7 +1082,7 @@
     "anthropic-dangerous-direct-browser-access": "true",
     "anthropic-version": "2023-06-01",
     "content-type": "application/json",
-    "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+    "user-agent": "claude-cli/2.1.159 (external, sdk-cli)",
     "x-app": "cli",
     "x-stainless-timeout": "600"
   },

--- a/packages/providers/claude-code/src/fingerprint/data.json
+++ b/packages/providers/claude-code/src/fingerprint/data.json
@@ -1052,7 +1052,7 @@
     "Write"
   ],
   "anthropic_beta": "claude-code-20250219,oauth-2025-04-20,context-1m-2025-08-07,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,extended-cache-ttl-2025-04-11",
-  "cc_version": "2.1.158",
+  "cc_version": "2.1.159",
   "header_order": [
     "Accept",
     "Authorization",
@@ -1082,7 +1082,7 @@
     "anthropic-dangerous-direct-browser-access": "true",
     "anthropic-version": "2023-06-01",
     "content-type": "application/json",
-    "user-agent": "claude-cli/2.1.158 (external, sdk-cli)",
+    "user-agent": "claude-cli/2.1.159 (external, sdk-cli)",
     "x-app": "cli",
     "x-stainless-timeout": "600"
   },


### PR DESCRIPTION
## Summary
- validate `@anthropic-ai/claude-code@2.1.159` locally with kyoli Claude doctors
- bump Claude Code `SUPPORTED_CC_RANGE.maxTested` to `2.1.159`
- refresh bundled Claude Code fingerprint `cc_version` / `user-agent` metadata only after template/wire checks showed label-only drift
- add a patch changeset for release

## Validation
- `claude --version` → `2.1.159 (Claude Code)`
- `pnpm --dir packages/cli run doctor claude --binary`
- `pnpm --dir packages/cli run doctor claude --template`
- `pnpm --dir packages/cli run doctor claude --wire` (23 pass, 1 known header-order warn, 0 fail)
- `pnpm --filter opencode-anthropic-multi-account test:contract:native` (111 passed)
- `pnpm --filter opencode-anthropic-multi-account check:sdk-drift` (clean)
- `pnpm --filter opencode-anthropic-multi-account test -- tests/claude-code/fingerprint/capture.test.ts tests/scripts/check-claude-code-static-oauth-drift.test.ts` (460 passed, 1 skipped)
- `pnpm changeset status --since=origin/main`

Closes #18.
