### PR TITLE
fix(claude-code): Refresh drift metadata for 2.1.161

### DIFF
--- a/.changeset/bright-claude-drift-2161.md
+++ b/.changeset/bright-claude-drift-2161.md
@@ -1,0 +1,5 @@
+---
+"opencode-anthropic-multi-account": patch
+---
+
+Refresh bundled Claude Code drift metadata to 2.1.161 and keep SDK drift checks scoped to SDK metadata.

--- a/.github/workflows/auto-merge-bot-prs.yml
+++ b/.github/workflows/auto-merge-bot-prs.yml
@@ -15,6 +15,8 @@ jobs:
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       !contains(github.event.pull_request.title, 'major')
     steps:
+      - uses: actions/checkout@v6
+
       - name: Enable native auto-merge
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/claude-code-drift-watch.yml
+++ b/.github/workflows/claude-code-drift-watch.yml
@@ -215,11 +215,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CC_VERSION="${{ needs.drift.outputs.cc_version }}"
-          TITLE_MATCH="Claude Code drift detected: v${CC_VERSION}"
-          LEGACY_TITLE_MATCH="Fingerprint drift detected: Claude Code v${CC_VERSION}"
           {
-            gh issue list --label claude-code-drift --state open --search "in:title \"${TITLE_MATCH}\"" --json number --jq '.[].number'
-            gh issue list --label fingerprint-drift --state open --search "in:title \"${LEGACY_TITLE_MATCH}\"" --json number --jq '.[].number' 2>/dev/null || true
+            gh issue list --label claude-code-drift --state open --json number --jq '.[].number'
+            gh issue list --label fingerprint-drift --state open --json number --jq '.[].number' 2>/dev/null || true
           } | sort -u > drift-issue-numbers.txt
           COMMENT="Resolved: static Claude Code drift scan is clean for v${CC_VERSION}."
           while IFS= read -r n; do

--- a/.github/workflows/sdk-drift-watch.yml
+++ b/.github/workflows/sdk-drift-watch.yml
@@ -38,6 +38,11 @@ jobs:
             cat sdk-drift.json
             exit 0
           fi
+          if [ "$code" -eq 2 ]; then
+            cat sdk-drift.json
+            echo "::warning::SDK drift check skipped because npm metadata was unavailable."
+            exit 0
+          fi
           cat sdk-drift.err
           exit "$code"
 

--- a/packages/anthropic-multi-account/scripts/check-sdk-drift.mjs
+++ b/packages/anthropic-multi-account/scripts/check-sdk-drift.mjs
@@ -8,15 +8,38 @@ import { fileURLToPath } from "node:url";
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const packageRoot = join(scriptDir, "..");
 const fingerprintPath = join(packageRoot, "src/claude-code/fingerprint/data.json");
+const NPM_VIEW_ATTEMPTS = 3;
+
+class InfraError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "InfraError";
+  }
+}
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
 
 function npmView(pkg, field) {
-  const output = execFileSync("npm", ["view", pkg, field, "--json"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-    timeout: 30_000,
-  }).trim();
-  if (!output) return undefined;
-  return JSON.parse(output);
+  let lastError;
+  for (let attempt = 1; attempt <= NPM_VIEW_ATTEMPTS; attempt += 1) {
+    try {
+      const output = execFileSync("npm", ["view", pkg, field, "--json"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 30_000,
+      }).trim();
+      if (!output) return undefined;
+      return JSON.parse(output);
+    } catch (error) {
+      lastError = error;
+      if (attempt < NPM_VIEW_ATTEMPTS) sleep(attempt * 1_000);
+    }
+  }
+
+  const detail = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new InfraError(`npm view ${pkg} ${field} failed after ${NPM_VIEW_ATTEMPTS} attempts: ${detail}`);
 }
 
 function loadBundledFingerprint() {
@@ -36,17 +59,8 @@ function main() {
   const agentSdkVersion = npmView("@anthropic-ai/claude-agent-sdk", "version") ?? null;
   const agentSdkDeps = npmView("@anthropic-ai/claude-agent-sdk", "dependencies");
   const upstreamStainless = normalizeRange(agentSdkDeps?.["@anthropic-ai/sdk"]);
-  const upstreamCcVersion = npmView("@anthropic-ai/claude-code", "version") ?? null;
 
   const drift = [];
-  if (upstreamCcVersion && bundledCcVersion && upstreamCcVersion !== bundledCcVersion) {
-    drift.push({
-      field: "cc_version",
-      bundled: bundledCcVersion,
-      upstream: upstreamCcVersion,
-      source: "@anthropic-ai/claude-code@latest",
-    });
-  }
 
   if (upstreamStainless && bundledStainless && upstreamStainless !== bundledStainless) {
     drift.push({
@@ -65,7 +79,6 @@ function main() {
       user_agent: bundledUserAgent,
     },
     upstream: {
-      cc_version: upstreamCcVersion,
       agent_sdk_version: agentSdkVersion,
       stainless_dep: upstreamStainless,
     },
@@ -80,6 +93,16 @@ function main() {
 try {
   main();
 } catch (error) {
-  process.stderr.write(`check-sdk-drift: ${error instanceof Error ? error.message : String(error)}\n`);
+  if (error instanceof InfraError) {
+    const report = {
+      checkedAt: new Date().toISOString(),
+      status: "infra_error",
+      error: error.message,
+    };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(2);
+  }
+
+  process.stderr.write(`check-sdk-drift: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
   process.exit(3);
 }

--- a/packages/anthropic-multi-account/src/claude-code/fingerprint/capture.ts
+++ b/packages/anthropic-multi-account/src/claude-code/fingerprint/capture.ts
@@ -35,7 +35,7 @@ const STATIC_HEADER_NAMES = [
 ] as const;
 const SUPPORTED_CC_RANGE = {
   min: "1.0.0",
-  maxTested: "2.1.159",
+  maxTested: "2.1.161",
 } as const;
 
 type TemplateSource = "bundled" | "cached" | "live";

--- a/packages/anthropic-multi-account/src/claude-code/fingerprint/data.json
+++ b/packages/anthropic-multi-account/src/claude-code/fingerprint/data.json
@@ -1052,7 +1052,7 @@
     "Write"
   ],
   "anthropic_beta": "claude-code-20250219,oauth-2025-04-20,context-1m-2025-08-07,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,extended-cache-ttl-2025-04-11",
-  "cc_version": "2.1.159",
+  "cc_version": "2.1.161",
   "header_order": [
     "Accept",
     "Authorization",
@@ -1082,7 +1082,7 @@
     "anthropic-dangerous-direct-browser-access": "true",
     "anthropic-version": "2023-06-01",
     "content-type": "application/json",
-    "user-agent": "claude-cli/2.1.159 (external, sdk-cli)",
+    "user-agent": "claude-cli/2.1.161 (external, sdk-cli)",
     "x-app": "cli",
     "x-stainless-timeout": "600"
   },

--- a/packages/providers/claude-code/src/fingerprint/data.json
+++ b/packages/providers/claude-code/src/fingerprint/data.json
@@ -1052,7 +1052,7 @@
     "Write"
   ],
   "anthropic_beta": "claude-code-20250219,oauth-2025-04-20,context-1m-2025-08-07,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,extended-cache-ttl-2025-04-11",
-  "cc_version": "2.1.159",
+  "cc_version": "2.1.161",
   "header_order": [
     "Accept",
     "Authorization",
@@ -1082,7 +1082,7 @@
     "anthropic-dangerous-direct-browser-access": "true",
     "anthropic-version": "2023-06-01",
     "content-type": "application/json",
-    "user-agent": "claude-cli/2.1.159 (external, sdk-cli)",
+    "user-agent": "claude-cli/2.1.161 (external, sdk-cli)",
     "x-app": "cli",
     "x-stainless-timeout": "600"
   },


### PR DESCRIPTION
Refresh Claude Code drift metadata to 2.1.161 and keep the SDK drift watcher from duplicating Claude Code version issues. The static OAuth scan now resolves the current 2.1.161 drift, while SDK drift only tracks SDK metadata changes.

**Claude Code drift**

Update the bundled template version, user-agent, and max tested range to 2.1.161. Clean static drift runs now close all open Claude Code drift issues instead of only the issue for the current version.

**SDK drift watcher**

Remove Claude Code version comparison from the SDK watcher so `sdk-drift` does not duplicate `claude-code-drift`. Registry lookup failures now emit an `infra_error` report and pass as a warning instead of creating a red workflow run.

**Dependabot auto-merge**

Checkout the repository before running `gh pr merge` so the dependabot auto-merge workflow has a git repository context.

Fixes #21
Fixes #25
Fixes #26
