### PR TITLE
ci(drift): Automate compat range drift PRs

### DIFF
--- a/.github/workflows/auto-merge-bot-prs.yml
+++ b/.github/workflows/auto-merge-bot-prs.yml
@@ -12,13 +12,43 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: |
-      github.event.pull_request.user.login == 'dependabot[bot]' &&
-      !contains(github.event.pull_request.title, 'major')
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      startsWith(github.event.pull_request.head.ref, 'bot/cc-drift-') ||
+      github.event.pull_request.head.ref == 'changeset-release/main'
     steps:
-      - uses: actions/checkout@v6
+      - name: Fetch Dependabot metadata
+        id: dep_meta
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        uses: dependabot/fetch-metadata@v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable native auto-merge
+        if: |
+          (
+            github.event.pull_request.user.login == 'dependabot[bot]' &&
+            steps.dep_meta.outputs.update-type != 'version-update:semver-major'
+          ) ||
+          startsWith(github.event.pull_request.head.ref, 'bot/cc-drift-') ||
+          github.event.pull_request.head.ref == 'changeset-release/main'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
-        run: gh pr merge "$PR" --auto --squash --delete-branch
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          TITLE: ${{ github.event.pull_request.title }}
+          UPDATE_TYPE: ${{ steps.dep_meta.outputs.update-type }}
+        run: |
+          set -euo pipefail
+          echo "Auto-merge candidate PR #${PR}"
+          echo "  author:      ${AUTHOR}"
+          echo "  branch:      ${BRANCH}"
+          echo "  title:       ${TITLE}"
+          echo "  update_type: ${UPDATE_TYPE:-n/a}"
+          echo ""
+
+          # The runner has no checkout, so gh cannot infer the repo from
+          # a git remote. Pass --repo explicitly or it fails with:
+          # fatal: not a git repository (or any of the parent directories): .git
+          gh pr merge "$PR" --repo "${{ github.repository }}" --auto --squash --delete-branch
+          echo "Auto-merge armed."

--- a/.github/workflows/claude-code-drift-watch.yml
+++ b/.github/workflows/claude-code-drift-watch.yml
@@ -16,7 +16,9 @@ on:
           - "true"
 
 permissions:
-  contents: read
+  contents: write
+  issues: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -86,11 +88,14 @@ jobs:
     if: needs.version_check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      issues: write
+      pull-requests: write
     outputs:
       exit_code: ${{ steps.drift.outputs.exit_code }}
       cc_version: ${{ steps.version.outputs.cc_version }}
       should_open_issue: ${{ steps.classify.outputs.should_open_issue }}
+      should_create_pr: ${{ steps.classify.outputs.should_create_pr }}
     steps:
       - uses: actions/checkout@v6
 
@@ -132,7 +137,9 @@ jobs:
         if: steps.drift.outputs.exit_code != '0'
         id: classify
         run: |
-          node packages/anthropic-multi-account/scripts/auto-draft-static-oauth-drift-fix.mjs
+          node packages/anthropic-multi-account/scripts/auto-draft-static-oauth-drift-fix.mjs \
+            drift-report.json \
+            auto-draft-result.json
           echo "should_open_issue=true" >> "$GITHUB_OUTPUT"
           cat auto-draft-result.json
 
@@ -147,6 +154,102 @@ jobs:
             auto-draft-result.json
           if-no-files-found: ignore
           retention-days: 30
+
+  auto_draft_pr:
+    needs: drift
+    if: needs.drift.outputs.should_create_pr == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Prefer a PAT so bot-created PRs trigger normal pull_request checks.
+          # GITHUB_TOKEN fallback can still push/create the PR, but downstream
+          # workflow triggering may be suppressed by GitHub loop protection.
+          token: ${{ secrets.KYOLI_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: claude-code-drift-report
+
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply auto-draftable drift fix
+        id: auto_draft
+        run: |
+          node packages/anthropic-multi-account/scripts/auto-draft-static-oauth-drift-fix.mjs \
+            drift-report.json \
+            auto-draft-result.json \
+            --apply
+          cat auto-draft-result.json
+
+      - name: Ensure drift label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create claude-code-drift \
+            --color FBCA04 \
+            --description "Claude Code package drift requires kyoli compatibility review" \
+            2>/dev/null || true
+
+      - name: Open PR and arm auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.KYOLI_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.auto_draft.outputs.branch_name }}
+          COMMIT_MESSAGE: ${{ steps.auto_draft.outputs.commit_message }}
+          PR_TITLE: ${{ steps.auto_draft.outputs.pr_title }}
+          PR_BODY_PATH: ${{ steps.auto_draft.outputs.pr_body_path }}
+          CHANGED_FILES: ${{ steps.auto_draft.outputs.changed_files }}
+        run: |
+          set -euo pipefail
+
+          existing_pr=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$existing_pr" ]; then
+            echo "PR #$existing_pr already exists for $BRANCH; arming auto-merge."
+            gh pr merge "$existing_pr" --repo "${{ github.repository }}" --auto --squash --delete-branch
+            exit 0
+          fi
+
+          git config user.email "actions@github.com"
+          git config user.name "kyoli-drift-watch[bot]"
+          git checkout -B "$BRANCH"
+
+          echo "$CHANGED_FILES" \
+            | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).join('\n')" \
+            | xargs -I {} git add -- {}
+
+          if git diff --cached --quiet; then
+            echo "No staged changes after auto-draft application; skipping PR."
+            exit 0
+          fi
+
+          git commit -m "$COMMIT_MESSAGE"
+          git push --force-with-lease origin "$BRANCH"
+
+          pr_url=$(gh pr create \
+            --repo "${{ github.repository }}" \
+            --head "$BRANCH" \
+            --base main \
+            --title "$PR_TITLE" \
+            --body-file "$PR_BODY_PATH" \
+            --label claude-code-drift)
+          echo "Opened $pr_url"
+
+          gh pr merge "$pr_url" --repo "${{ github.repository }}" --auto --squash --delete-branch
+          echo "Auto-merge armed."
+
 
   manual_issue:
     needs: drift

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,24 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
+
+      - name: Enable auto-merge for release PR
+        if: steps.changesets.outputs.published != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.KYOLI_RELEASE_BOT_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          pr=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head changeset-release/main \
+            --state open \
+            --json number \
+            --jq '.[0].number')
+
+          if [ -z "$pr" ]; then
+            echo "No open Changesets release PR to auto-merge."
+            exit 0
+          fi
+
+          echo "Arming auto-merge for Changesets release PR #$pr."
+          gh pr merge "$pr" --repo "${{ github.repository }}" --auto --squash --delete-branch

--- a/packages/anthropic-multi-account/scripts/auto-draft-static-oauth-drift-fix.mjs
+++ b/packages/anthropic-multi-account/scripts/auto-draft-static-oauth-drift-fix.mjs
@@ -1,20 +1,57 @@
-import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
-import { pathToFileURL } from "node:url";
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const reportPath = process.argv[2] ?? "drift-report.json";
 const resultPath = process.argv[3] ?? "auto-draft-result.json";
+const shouldApply = process.argv.includes("--apply");
+
+function packageRoot() {
+  return join(dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+function sanitizeVersion(version) {
+  return String(version ?? "unknown").replace(/[^0-9A-Za-z.-]/g, "-");
+}
+
+function branchNameForVersion(version) {
+  return `bot/cc-drift-v${sanitizeVersion(version)}`;
+}
+
+function changesetPathForVersion(version) {
+  return join(".changeset", `claude-code-${sanitizeVersion(version).replace(/\./g, "-")}-drift.md`);
+}
+
+function prTitleForVersion(version) {
+  return `fix(claude-code): Refresh drift metadata for ${version}`;
+}
+
+function commitMessageForVersion(version) {
+  return prTitleForVersion(version);
+}
+
+function prBodyForVersion(version, report) {
+  const checkedAt = report.checkedAt ?? new Date().toISOString();
+  return `## Summary\n\nAutomated compat-range refresh for \`@anthropic-ai/claude-code@${version}\`.\n\nThis PR is intentionally limited to the static \`compat.range\` drift class: OAuth URLs/client ID and scanner layout did not drift, so it only advances kyoli's max-tested Claude Code range and adds a patch changeset. Template or wire-shape drift must stay human-gated.\n\n## Validation gate\n\nRequired PR checks must pass before native auto-merge can complete. If local doctor/template/wire validation disagrees with this static report, close this PR and handle the drift manually.\n\n## Drift report\n\n- checkedAt: \`${checkedAt}\`\n- ccVersion: \`${version}\`\n- categories: \`${(report.items ?? []).map((item) => item.category).join(", ")}\`\n\n\`\`\`json\n${JSON.stringify(report, null, 2)}\n\`\`\`\n`;
+}
 
 function writeGithubOutputs(result) {
   if (!process.env.GITHUB_OUTPUT) {
     return;
   }
 
-  appendFileSync(process.env.GITHUB_OUTPUT, `should_create_pr=${result.shouldCreatePr}\n`);
-  appendFileSync(process.env.GITHUB_OUTPUT, "changed_files=[]\n");
-  appendFileSync(process.env.GITHUB_OUTPUT, "branch_name=\n");
-  appendFileSync(process.env.GITHUB_OUTPUT, "commit_message=\n");
-  appendFileSync(process.env.GITHUB_OUTPUT, "pr_title=\n");
-  appendFileSync(process.env.GITHUB_OUTPUT, "pr_body_path=\n");
+  const outputs = {
+    should_create_pr: result.shouldCreatePr,
+    changed_files: JSON.stringify(result.changedFiles ?? []),
+    branch_name: result.branchName ?? "",
+    commit_message: result.commitMessage ?? "",
+    pr_title: result.prTitle ?? "",
+    pr_body_path: result.prBodyPath ?? "",
+  };
+
+  for (const [key, value] of Object.entries(outputs)) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+  }
 }
 
 function writeResult(result) {
@@ -22,11 +59,15 @@ function writeResult(result) {
   writeGithubOutputs(result);
 }
 
-function classifyDriftReport(report) {
+function categoriesFromReport(report) {
   const items = Array.isArray(report.items) ? report.items : [];
-  const categories = items
+  return items
     .map((item) => item?.category)
     .filter((category) => typeof category === "string");
+}
+
+function classifyDriftReport(report) {
+  const categories = categoriesFromReport(report);
 
   if (!report.drift || categories.length === 0) {
     return {
@@ -37,10 +78,21 @@ function classifyDriftReport(report) {
   }
 
   if (categories.length === 1 && categories[0] === "compat.range") {
+    if (!report.ccVersion || report.ccVersion === "unknown") {
+      return {
+        shouldCreatePr: false,
+        changedFiles: [],
+        reason: "compat.range drift is auto-fixable only when ccVersion is known",
+      };
+    }
+
     return {
-      shouldCreatePr: false,
+      shouldCreatePr: true,
       changedFiles: [],
-      reason: "compat.range requires local Claude Code doctor/template validation before patching",
+      reason: "compat.range-only drift can be auto-drafted behind PR checks",
+      branchName: branchNameForVersion(report.ccVersion),
+      commitMessage: commitMessageForVersion(report.ccVersion),
+      prTitle: prTitleForVersion(report.ccVersion),
     };
   }
 
@@ -51,10 +103,60 @@ function classifyDriftReport(report) {
   };
 }
 
-export { classifyDriftReport };
+function replaceMaxTested(source, nextVersion) {
+  const pattern = /(maxTested:\s*")[^"]+(")/;
+  if (!pattern.test(source)) {
+    throw new Error("Unable to find SUPPORTED_CC_RANGE.maxTested in capture.ts");
+  }
+  return source.replace(pattern, `$1${nextVersion}$2`);
+}
+
+function applyCompatRangeFix(report, options = {}) {
+  const root = options.packageRootPath ?? packageRoot();
+  const repoRoot = join(root, "..", "..");
+  const version = report.ccVersion;
+  const sourcePath = join(root, "src/claude-code/fingerprint/capture.ts");
+  const sourceRelativePath = "packages/anthropic-multi-account/src/claude-code/fingerprint/capture.ts";
+  const changesetRelativePath = changesetPathForVersion(version);
+  const changesetFullPath = join(repoRoot, changesetRelativePath);
+  const prBodyPath = "pr-body.md";
+
+  const source = readFileSync(sourcePath, "utf8");
+  const updatedSource = replaceMaxTested(source, version);
+  writeFileSync(sourcePath, updatedSource);
+
+  mkdirSync(dirname(changesetFullPath), { recursive: true });
+  writeFileSync(
+    changesetFullPath,
+    `---\n"opencode-anthropic-multi-account": patch\n---\n\nRefresh Claude Code static drift compatibility metadata for \`@anthropic-ai/claude-code@${version}\`.\n`,
+  );
+
+  writeFileSync(join(repoRoot, prBodyPath), prBodyForVersion(version, report));
+
+  return {
+    shouldCreatePr: true,
+    changedFiles: [sourceRelativePath, changesetRelativePath],
+    reason: "compat.range-only drift auto-fix applied",
+    branchName: branchNameForVersion(version),
+    commitMessage: commitMessageForVersion(version),
+    prTitle: prTitleForVersion(version),
+    prBodyPath,
+  };
+}
+
+export {
+  applyCompatRangeFix,
+  branchNameForVersion,
+  changesetPathForVersion,
+  classifyDriftReport,
+  replaceMaxTested,
+};
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const report = JSON.parse(readFileSync(reportPath, "utf8"));
-  const result = classifyDriftReport(report);
+  const classified = classifyDriftReport(report);
+  const result = shouldApply && classified.shouldCreatePr
+    ? applyCompatRangeFix(report)
+    : classified;
   writeResult(result);
 }

--- a/packages/anthropic-multi-account/tests/scripts/auto-draft-static-oauth-drift-fix.test.ts
+++ b/packages/anthropic-multi-account/tests/scripts/auto-draft-static-oauth-drift-fix.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  applyCompatRangeFix,
+  branchNameForVersion,
+  classifyDriftReport,
+  replaceMaxTested,
+} from "../../scripts/auto-draft-static-oauth-drift-fix.mjs";
+
+const tempDirs: string[] = [];
+
+function makeTempPackageRoot() {
+  const repoRoot = mkdtempSync(join(tmpdir(), "kyoli-drift-auto-"));
+  tempDirs.push(repoRoot);
+  const packageRoot = join(repoRoot, "packages/anthropic-multi-account");
+  mkdirSync(join(packageRoot, "src/claude-code/fingerprint"), { recursive: true });
+  writeFileSync(
+    join(packageRoot, "src/claude-code/fingerprint/capture.ts"),
+    `export const SUPPORTED_CC_RANGE = {\n  min: "1.0.0",\n  maxTested: "2.1.161",\n} as const;\n`,
+  );
+  return { repoRoot, packageRoot };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("auto-draft static OAuth drift fix", () => {
+  test("classifies compat.range-only drift as auto-draftable", () => {
+    const result = classifyDriftReport({
+      drift: true,
+      ccVersion: "2.1.162",
+      items: [{ category: "compat.range" }],
+    });
+
+    expect(result.shouldCreatePr).toBe(true);
+    expect(result.branchName).toBe("bot/cc-drift-v2.1.162");
+    expect(result.prTitle).toContain("2.1.162");
+  });
+
+  test("keeps OAuth drift human-gated", () => {
+    const result = classifyDriftReport({
+      drift: true,
+      ccVersion: "2.1.162",
+      items: [{ category: "compat.range" }, { category: "oauth.clientId" }],
+    });
+
+    expect(result.shouldCreatePr).toBe(false);
+    expect(result.reason).toContain("manual drift review");
+  });
+
+  test("updates maxTested without touching the supported minimum", () => {
+    const updated = replaceMaxTested(
+      `const range = { min: "1.0.0", maxTested: "2.1.161" }`,
+      "2.1.162",
+    );
+
+    expect(updated).toContain(`min: "1.0.0"`);
+    expect(updated).toContain(`maxTested: "2.1.162"`);
+  });
+
+  test("applies a compat.range fix and writes a patch changeset", () => {
+    const { repoRoot, packageRoot } = makeTempPackageRoot();
+    const result = applyCompatRangeFix({
+      drift: true,
+      checkedAt: "2026-06-04T00:00:00Z",
+      ccVersion: "2.1.162",
+      items: [{ category: "compat.range" }],
+    }, { packageRootPath: packageRoot });
+
+    expect(result.changedFiles).toEqual([
+      "packages/anthropic-multi-account/src/claude-code/fingerprint/capture.ts",
+      ".changeset/claude-code-2-1-162-drift.md",
+    ]);
+    expect(readFileSync(join(packageRoot, "src/claude-code/fingerprint/capture.ts"), "utf8"))
+      .toContain(`maxTested: "2.1.162"`);
+    expect(readFileSync(join(repoRoot, ".changeset/claude-code-2-1-162-drift.md"), "utf8"))
+      .toContain("opencode-anthropic-multi-account");
+    expect(readFileSync(join(repoRoot, "pr-body.md"), "utf8"))
+      .toContain("compat.range");
+  });
+
+  test("sanitizes branch names from version strings", () => {
+    expect(branchNameForVersion("2.1.162+build/meta")).toBe("bot/cc-drift-v2.1.162-build-meta");
+  });
+});


### PR DESCRIPTION
Wire Claude Code compat-range drift into an automated PR path while keeping higher-risk drift classes human-gated. When the static drift report contains only `compat.range`, the watcher now drafts a bot PR with a max-tested range bump and patch changeset, then arms native auto-merge behind the normal PR checks.

**Bot merge flow**

The auto-merge workflow now uses structured Dependabot metadata, includes drift bot and Changesets release branches, and passes `--repo` to `gh pr merge` so it no longer depends on a checked-out git repository on the runner.

**Release continuation**

After Changesets creates a release PR, the release workflow attempts to arm native auto-merge for `changeset-release/main` so a merged drift PR can continue into publish without an extra manual merge click.

**Manual safety boundary**

OAuth, scanner, template, and wire-shape drift still fall back to the existing issue path. The auto-draft script only patches `compat.range` drift with a known Claude Code version, and tests cover the classification and patch generation behavior.
