### PR TITLE
ci(drift): Require bot PATs for automated PR loops

### DIFF
--- a/.github/workflows/claude-code-drift-watch.yml
+++ b/.github/workflows/claude-code-drift-watch.yml
@@ -163,12 +163,19 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Require drift bot PAT
+        env:
+          KYOLI_DRIFT_BOT_PAT: ${{ secrets.KYOLI_DRIFT_BOT_PAT }}
+        run: |
+          if [ -z "$KYOLI_DRIFT_BOT_PAT" ]; then
+            echo "::error::KYOLI_DRIFT_BOT_PAT is required to open drift PRs because GITHUB_TOKEN-created PRs do not reliably trigger required checks."
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
         with:
-          # Prefer a PAT so bot-created PRs trigger normal pull_request checks.
-          # GITHUB_TOKEN fallback can still push/create the PR, but downstream
-          # workflow triggering may be suppressed by GitHub loop protection.
-          token: ${{ secrets.KYOLI_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}
+          # Use a PAT so bot-created PRs trigger normal pull_request checks.
+          token: ${{ secrets.KYOLI_DRIFT_BOT_PAT }}
 
       - uses: actions/download-artifact@v8
         with:
@@ -206,7 +213,7 @@ jobs:
 
       - name: Open PR and arm auto-merge
         env:
-          GH_TOKEN: ${{ secrets.KYOLI_DRIFT_BOT_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.KYOLI_DRIFT_BOT_PAT }}
           BRANCH: ${{ steps.auto_draft.outputs.branch_name }}
           COMMIT_MESSAGE: ${{ steps.auto_draft.outputs.commit_message }}
           PR_TITLE: ${{ steps.auto_draft.outputs.pr_title }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,15 @@ jobs:
       - name: Enable auto-merge for release PR
         if: steps.changesets.outputs.published != 'true'
         env:
-          GH_TOKEN: ${{ secrets.KYOLI_RELEASE_BOT_PAT || secrets.GITHUB_TOKEN }}
+          KYOLI_RELEASE_BOT_PAT: ${{ secrets.KYOLI_RELEASE_BOT_PAT }}
         run: |
           set -euo pipefail
+          if [ -z "$KYOLI_RELEASE_BOT_PAT" ]; then
+            echo "::warning::KYOLI_RELEASE_BOT_PAT is not configured; leaving the Changesets release PR for manual merge so publish is not suppressed by GITHUB_TOKEN loop protection."
+            exit 0
+          fi
+          export GH_TOKEN="$KYOLI_RELEASE_BOT_PAT"
+
           pr=$(gh pr list \
             --repo "${{ github.repository }}" \
             --head changeset-release/main \


### PR DESCRIPTION
Tighten the newly merged drift automation so automated PR loops only use real bot PATs. This keeps GitHub from suppressing the pull_request checks that drift PR auto-merge relies on.

**Drift PR safety**

The compat-range auto-draft job now fails fast unless `KYOLI_DRIFT_BOT_PAT` is configured, then uses that PAT for checkout, PR creation, and auto-merge arming.

**Release PR safety**

The release workflow now skips Changesets release PR auto-merge when `KYOLI_RELEASE_BOT_PAT` is missing, leaving the PR for manual merge instead of using `GITHUB_TOKEN` and risking suppressed publish workflows.
