### PR TITLE
fix(claude-code): Refresh drift metadata for 2.1.168

### DIFF
--- a/.changeset/claude-code-2-1-168-drift.md
+++ b/.changeset/claude-code-2-1-168-drift.md
@@ -1,0 +1,5 @@
+---
+"opencode-anthropic-multi-account": patch
+---
+
+Refresh Claude Code static drift compatibility metadata for `@anthropic-ai/claude-code@2.1.168`.

--- a/packages/anthropic-multi-account/src/claude-code/fingerprint/capture.ts
+++ b/packages/anthropic-multi-account/src/claude-code/fingerprint/capture.ts
@@ -35,7 +35,7 @@ const STATIC_HEADER_NAMES = [
 ] as const;
 const SUPPORTED_CC_RANGE = {
   min: "1.0.0",
-  maxTested: "2.1.167",
+  maxTested: "2.1.168",
 } as const;
 
 type TemplateSource = "bundled" | "cached" | "live";


### PR DESCRIPTION
## Summary

Automated compat-range refresh for `@anthropic-ai/claude-code@2.1.168`.

This PR is intentionally limited to the static `compat.range` drift class: OAuth URLs/client ID and scanner layout did not drift, so it only advances kyoli's max-tested Claude Code range and adds a patch changeset. Template or wire-shape drift must stay human-gated.

## Validation gate

Required PR checks must pass before native auto-merge can complete. If local doctor/template/wire validation disagrees with this static report, close this PR and handle the drift manually.

## Drift report

- checkedAt: `2026-06-07T01:01:27.274Z`
- ccVersion: `2.1.168`
- categories: `compat.range`

```json
{
  "drift": true,
  "checkedAt": "2026-06-07T01:01:27.274Z",
  "ccVersion": "2.1.168",
  "pinned": {
    "clientId": "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
    "authorizeUrl": "https://claude.ai/oauth/authorize",
    "tokenUrl": "https://platform.claude.com/v1/oauth/token",
    "maxTested": "2.1.167"
  },
  "scanned": {
    "clientId": "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
    "authorizeUrl": "https://claude.ai/oauth/authorize",
    "tokenUrl": "https://platform.claude.com/v1/oauth/token",
    "baseApiUrl": "https://api.anthropic.com"
  },
  "scanTarget": {
    "package": "@anthropic-ai/claude-code-linux-x64",
    "kind": "native-package",
    "path": "native/package/claude",
    "platform": "linux-x64"
  },
  "scriptPath": "scripts/check-claude-code-static-oauth-drift.mjs",
  "items": [
    {
      "category": "compat.range",
      "severity": "medium",
      "message": "CC v2.1.168 is newer than maxTested v2.1.167."
    }
  ]
}
```
