### PR TITLE
ci(release): Use release bot token for Changesets PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           publish: pnpm run release
           createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.KYOLI_RELEASE_BOT_PAT || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
Release PR updates now prefer the configured release bot PAT when Changesets creates or refreshes the release branch. This keeps the existing GITHUB_TOKEN fallback, but lets normal pull_request checks run when the PAT is available so main branch protection can observe the required CI and CodeQL jobs.

**Release PR Triggering**

Changesets still publishes with the same npm token and provenance settings. The only behavior change is which GitHub token is used for PR branch updates, avoiding GitHub's GITHUB_TOKEN workflow-loop suppression for release PR checks.