### PR TITLE
fix(claude-code): Preserve user payload fidelity

### DIFF
--- a/.changeset/claude-code-payload-fidelity.md
+++ b/.changeset/claude-code-payload-fidelity.md
@@ -1,0 +1,5 @@
+---
+"opencode-anthropic-multi-account": patch
+---
+
+Preserve user message content while refreshing Claude Code fingerprint labels and prompt cache breakpoints.

--- a/packages/anthropic-multi-account/src/claude-code/fingerprint/data.json
+++ b/packages/anthropic-multi-account/src/claude-code/fingerprint/data.json
@@ -1052,7 +1052,7 @@
     "Write"
   ],
   "anthropic_beta": "claude-code-20250219,oauth-2025-04-20,context-1m-2025-08-07,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,extended-cache-ttl-2025-04-11",
-  "cc_version": "2.1.161",
+  "cc_version": "2.1.169",
   "header_order": [
     "Accept",
     "Authorization",
@@ -1082,7 +1082,7 @@
     "anthropic-dangerous-direct-browser-access": "true",
     "anthropic-version": "2023-06-01",
     "content-type": "application/json",
-    "user-agent": "claude-cli/2.1.161 (external, sdk-cli)",
+    "user-agent": "claude-cli/2.1.169 (external, sdk-cli)",
     "x-app": "cli",
     "x-stainless-timeout": "600"
   },

--- a/packages/anthropic-multi-account/src/request/client-adapter.ts
+++ b/packages/anthropic-multi-account/src/request/client-adapter.ts
@@ -35,6 +35,15 @@ const FRAMEWORK_PATTERNS: RegExp[] = [
   /\bsessions_[a-z_]+\b/gi,
 ];
 
+// Message and tool-result content is user-owned code/data. Only scrub
+// distinctive multi-word framework identifiers here; bare words like
+// `continue`, `cursor`, `gateway`, `openai`, `hermes`, or `powered by ...`
+// can be legitimate payload text and must not be removed.
+const CONTENT_FRAMEWORK_PATTERNS: RegExp[] = [
+  /\b(roo[- ]?cline|roo[- ]?code|big[- ]?agi|claude[- ]?bridge)\b/gi,
+  /\b(librechat|typingmind)\b/gi,
+];
+
 export type JsonRecord = Record<string, unknown>;
 
 export type ContentBlock = JsonRecord & {
@@ -67,7 +76,7 @@ export function normalizeAnthropicClientRequest(inputBody: JsonRecord): AdaptedC
 
   for (const message of messages) {
     if (typeof message.content === "string") {
-      message.content = sanitizeAndScrubText(message.content);
+      message.content = sanitizeAndScrubContent(message.content);
       continue;
     }
 
@@ -127,10 +136,10 @@ export function sanitizeMessages(body: JsonRecord): void {
   }
 }
 
-export function scrubFrameworkIdentifiers(text: string): string {
+function scrubWithPatterns(text: string, patterns: readonly RegExp[]): string {
   let result = text;
 
-  for (const pattern of FRAMEWORK_PATTERNS) {
+  for (const pattern of patterns) {
     pattern.lastIndex = 0;
     result = result.replace(pattern, (match, ...args: unknown[]) => {
       const offset = args.at(-2);
@@ -156,6 +165,14 @@ export function scrubFrameworkIdentifiers(text: string): string {
   }
 
   return result;
+}
+
+export function scrubFrameworkIdentifiers(text: string): string {
+  return scrubWithPatterns(text, FRAMEWORK_PATTERNS);
+}
+
+export function scrubFrameworkIdentifiersInContent(text: string): string {
+  return scrubWithPatterns(text, CONTENT_FRAMEWORK_PATTERNS);
 }
 
 export function truncateToolResultText(text: string): string {
@@ -187,6 +204,12 @@ function sanitizeAndScrubText(text: string): string {
     .trim();
 }
 
+function sanitizeAndScrubContent(text: string): string {
+  return scrubFrameworkIdentifiersInContent(sanitizeContent(text))
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 function stripCacheControl(value: unknown): void {
   if (Array.isArray(value)) {
     for (const item of value) {
@@ -208,7 +231,7 @@ function stripCacheControl(value: unknown): void {
 
 function sanitizeMessageBlock(block: ContentBlock): void {
   if (typeof block.text === "string") {
-    block.text = sanitizeAndScrubText(block.text);
+    block.text = sanitizeAndScrubContent(block.text);
   }
 
   if (block.type !== "tool_result") {
@@ -216,7 +239,7 @@ function sanitizeMessageBlock(block: ContentBlock): void {
   }
 
   if (typeof block.content === "string") {
-    block.content = truncateToolResultText(sanitizeAndScrubText(block.content));
+    block.content = truncateToolResultText(sanitizeAndScrubContent(block.content));
     return;
   }
 
@@ -229,7 +252,7 @@ function sanitizeMessageBlock(block: ContentBlock): void {
       if (isRecord(item) && typeof item.text === "string") {
         return {
           ...item,
-          text: truncateToolResultText(sanitizeAndScrubText(item.text)),
+          text: truncateToolResultText(sanitizeAndScrubContent(item.text)),
         };
       }
 

--- a/packages/anthropic-multi-account/tests/claude-code/cli-version.test.ts
+++ b/packages/anthropic-multi-account/tests/claude-code/cli-version.test.ts
@@ -39,6 +39,10 @@ afterAll(() => {
 });
 
 describe("detectCliVersion", () => {
+  test("tracks the bundled fingerprint label", () => {
+    expect(DEFAULT_CLI_VERSION).toBe("2.1.169");
+  });
+
   test("returns parsed semver when the Claude binary is available", () => {
     execFileSyncMock.mockReturnValue("claude v2.3.5\n");
 

--- a/packages/anthropic-multi-account/tests/contract/native-contract-invariants.test.ts
+++ b/packages/anthropic-multi-account/tests/contract/native-contract-invariants.test.ts
@@ -246,7 +246,8 @@ describe("native-plugin request contract invariants", () => {
       "project_database_lookup",
     ]);
     expect(tools.every((tool) => isRecord(tool.input_schema))).toBe(true);
-    expect(JSON.stringify(body.messages)).not.toContain("cache_control");
+    const messages = body.messages as Array<{ content?: Array<{ cache_control?: { type: string } }> }>;
+    expect(messages.at(-1)?.content?.at(-1)?.cache_control).toEqual({ type: "ephemeral" });
     expect(JSON.stringify(body.messages)).not.toContain('"type":"thinking"');
     expect(JSON.stringify(body.system)).not.toContain("Remove this orchestration note.");
   });
@@ -268,6 +269,7 @@ describe("native-plugin request contract invariants", () => {
         name: "Read",
         description: "Read files",
         input_schema: { type: "object", properties: { file_path: { type: "string" } } },
+        cache_control: { type: "ephemeral" },
       },
     ]);
   });
@@ -305,7 +307,12 @@ describe("native-plugin request contract invariants", () => {
       {
         role: "user",
         content: [
-          { type: "tool_result", tool_use_id: "toolu_1", content: "" },
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            content: "",
+            cache_control: { type: "ephemeral" },
+          },
         ],
       },
     ]);

--- a/packages/anthropic-multi-account/tests/index.test.ts
+++ b/packages/anthropic-multi-account/tests/index.test.ts
@@ -302,9 +302,9 @@ describe("index", () => {
       const assistantBlocks = messages[1]?.content as Array<{ name?: string; type?: string }> | undefined;
       const toolUse = assistantBlocks?.find((block) => block.type === "tool_use");
       expect(toolUse?.name).toBe(toolNames[0]);
-      expect(containsProperty(messages, "cache_control")).toBe(false);
+      expect(messages.at(-1)?.content?.at(-1)?.cache_control).toEqual({ type: "ephemeral" });
       expect(JSON.stringify(messages)).not.toContain('"type":"thinking"');
-      expect(JSON.stringify(messages)).not.toContain("OpenCode request");
+      expect(JSON.stringify(messages)).toContain("OpenCode request");
     } finally {
       globalThis.fetch = originalFetch;
       await cleanup();

--- a/packages/anthropic-multi-account/tests/request/client-adapter.test.ts
+++ b/packages/anthropic-multi-account/tests/request/client-adapter.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeAnthropicClientRequest,
   sanitizeMessages,
   scrubFrameworkIdentifiers,
+  scrubFrameworkIdentifiersInContent,
 } from "../../src/request/client-adapter";
 
 describe("client-adapter", () => {
@@ -39,6 +40,13 @@ describe("client-adapter", () => {
     expect(output.toLowerCase()).not.toContain("cursor");
     expect(output.toLowerCase()).not.toContain("openai");
     expect(output.toLowerCase()).not.toContain("gateway");
+  });
+
+  test("scrubFrameworkIdentifiersInContent preserves user code and data tokens", () => {
+    const input = "continue; const cursor = gateway(OpenAI, Hermes); // Powered by Stripe";
+
+    expect(scrubFrameworkIdentifiersInContent(input)).toBe(input);
+    expect(scrubFrameworkIdentifiersInContent("Roo Cline used LibreChat")).toBe(" used ");
   });
 
   test("normalizeAnthropicClientRequest strips OpenCode adapter fields before Claude Code replay", () => {
@@ -86,12 +94,45 @@ describe("client-adapter", () => {
     expect("output_config" in adapted.body).toBe(false);
     expect(adapted.systemTexts).toEqual(["Local  system"]);
     expect(messages[0]?.content).toEqual([
-      { type: "text", text: "Use  but keep /tmp/kyoli/opencode-state" },
+      { type: "text", text: "Use opencode but keep /tmp/kyoli/opencode-state" },
     ]);
     expect(messages[1]?.content).toEqual([
       { type: "text", text: "Visible answer" },
     ]);
     expect(JSON.stringify(adapted.body)).not.toContain("cache_control");
+  });
+
+  test("normalizeAnthropicClientRequest preserves code-like content while sanitizing", () => {
+    const adapted = normalizeAnthropicClientRequest({
+      system: "OpenCode gateway system",
+      messages: [
+        {
+          role: "user",
+          content: "continue; const cursor = gateway(OpenAI, Hermes); // Powered by Stripe",
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_1",
+              content: [
+                { type: "text", text: "continue cursor gateway OpenAI Hermes Powered by Stripe" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(adapted.systemTexts).toEqual(["system"]);
+    expect(adapted.messages[0]?.content).toBe(
+      "continue; const cursor = gateway(OpenAI, Hermes); // Powered by Stripe",
+    );
+    const second = adapted.messages[1] as { content: Array<{ content: Array<{ text: string }> }> };
+    expect(second.content[0]?.content[0]?.text).toBe(
+      "continue cursor gateway OpenAI Hermes Powered by Stripe",
+    );
   });
 
   test("normalizeAnthropicClientRequest drops empty turns but preserves tool_result turns", () => {

--- a/packages/anthropic-multi-account/tests/request/transform.test.ts
+++ b/packages/anthropic-multi-account/tests/request/transform.test.ts
@@ -167,7 +167,7 @@ describe("transformRequestBody", () => {
 
       const parsed = JSON.parse(transformed as string) as {
         system: Array<{ text?: string }>;
-        tools: Array<{ name?: string; input_schema?: unknown }>;
+        tools: Array<{ name?: string; input_schema?: unknown; cache_control?: { type?: string } }>;
         messages: Array<{ role?: string; content?: Array<Record<string, unknown>> }>;
         metadata?: { user_id?: string };
         thinking?: Record<string, unknown>;
@@ -195,10 +195,11 @@ describe("transformRequestBody", () => {
       expect("thinking" in parsed).toBe(false);
       expect("context_management" in parsed).toBe(false);
       expect("output_config" in parsed).toBe(false);
-      expect(JSON.stringify(parsed.messages)).not.toContain("cache_control");
+      expect(parsed.tools.at(-1)?.cache_control).toEqual({ type: "ephemeral" });
+      expect(parsed.messages.at(-1)?.content?.at(-1)?.cache_control).toEqual({ type: "ephemeral" });
       expect(JSON.stringify(parsed.messages)).not.toContain('"thinking"');
       expect(parsed.messages[0]?.content?.[0]?.text).toContain("/tmp/kyoli/opencode-state");
-      expect(parsed.messages[0]?.content?.[0]?.text).not.toContain("OpenCode");
+      expect(parsed.messages[0]?.content?.[0]?.text).toContain("OpenCode");
       expect(parsed.messages[1]?.content?.[0]?.name).toBe(parsed.tools[0]?.name);
       expect(parsed.messages[2]?.content?.[0]?.content).toBe("Found  retry guidance.");
     } finally {

--- a/packages/anthropic-multi-account/tests/request/upstream-request.test.ts
+++ b/packages/anthropic-multi-account/tests/request/upstream-request.test.ts
@@ -206,7 +206,9 @@ describe("upstream-request", () => {
     expect("thinking" in result).toBe(false);
     expect("context_management" in result).toBe(false);
     expect(result.output_config).toEqual({ effort: "high" });
-    expect(result.tools).toEqual([{ name: "OriginalTool", description: "legacy" }]);
+    expect(result.tools).toEqual([
+      { name: "OriginalTool", description: "legacy", cache_control: { type: "ephemeral" } },
+    ]);
     expect(messages).toHaveLength(3);
     expect(messages[1]?.content).toEqual([{ type: "text", text: "Working on it" }]);
     expect(truncated.length).toBeLessThanOrEqual(MAX_TOOL_RESULT_TEXT_LENGTH + TRUNCATION_SUFFIX.length);
@@ -232,7 +234,12 @@ describe("upstream-request", () => {
     const assistantMessage = messages[1] as { content: Array<{ type?: string; text?: string; name?: string; input?: unknown }> };
 
     expect(assistantMessage.content).toEqual([
-      { type: "tool_use", name: "AskUserQuestion", input: { question: "x" } },
+      {
+        type: "tool_use",
+        name: "AskUserQuestion",
+        input: { question: "x" },
+        cache_control: { type: "ephemeral" },
+      },
     ]);
   });
 
@@ -249,7 +256,7 @@ describe("upstream-request", () => {
 
     expect(messages).toEqual([
       { role: "user", content: [{ type: "text", text: "hello" }] },
-      { role: "assistant", content: [{ type: "text", text: "partial answer" }] },
+      { role: "assistant", content: [{ type: "text", text: "partial answer", cache_control: { type: "ephemeral" } }] },
     ]);
   });
 
@@ -306,7 +313,12 @@ describe("upstream-request", () => {
     ]);
     expect(messages[2]?.role).toBe("user");
     expect(messages[2]?.content).toEqual([
-      { type: "tool_result", tool_use_id: "toolu_1", content: "" },
+      {
+        type: "tool_result",
+        tool_use_id: "toolu_1",
+        content: "",
+        cache_control: { type: "ephemeral" },
+      },
     ]);
   });
 
@@ -578,7 +590,12 @@ describe("upstream-request", () => {
 
     expect(result.tools).toEqual([
       { name: "question", description: "OpenCode question tool", input_schema: { type: "object", properties: { questions: { type: "array" } } } },
-      { name: "bash", description: "OpenCode bash tool", input_schema: { type: "object", properties: { command: { type: "string" } } } },
+      {
+        name: "bash",
+        description: "OpenCode bash tool",
+        input_schema: { type: "object", properties: { command: { type: "string" } } },
+        cache_control: { type: "ephemeral" },
+      },
     ]);
   });
 
@@ -607,7 +624,10 @@ describe("upstream-request", () => {
       messages: [{ role: "user", content: "hello" }],
     }, createIdentity(), template);
 
-    expect(result.tools).toEqual(incomingTools);
+    expect(result.tools).toEqual([
+      ...incomingTools.slice(0, -1),
+      { ...incomingTools[incomingTools.length - 1], cache_control: { type: "ephemeral" } },
+    ]);
   });
 
   test("buildUpstreamRequest preserves tool_use names for the later request-scoped flow", () => {

--- a/packages/anthropic-multi-account/tests/runtime/factory.test.ts
+++ b/packages/anthropic-multi-account/tests/runtime/factory.test.ts
@@ -292,7 +292,12 @@ describe("runtime-factory", () => {
     ]);
     expect(body.messages[2]?.role).toBe("user");
     expect(body.messages[2]?.content).toEqual([
-      { type: "tool_result", tool_use_id: "toolu_1", content: "" },
+      {
+        type: "tool_result",
+        tool_use_id: "toolu_1",
+        content: "",
+        cache_control: { type: "ephemeral" },
+      },
     ]);
   });
 
@@ -342,7 +347,7 @@ describe("runtime-factory", () => {
       expect(firstBody.tools.every((tool) => Boolean(tool.input_schema))).toBe(true);
       expect(firstBody.tool_choice?.name).toBe(firstBody.tools[1]?.name);
       expect(firstBody.messages[1]?.content?.[0]?.name).toBe(firstBody.tools[0]?.name);
-      expect(JSON.stringify(firstBody.messages)).not.toContain("cache_control");
+      expect(firstBody.messages.at(-1)?.content?.at(-1)?.cache_control).toEqual({ type: "ephemeral" });
       expect(JSON.stringify(firstBody.messages)).not.toContain('"thinking"');
 
       const firstHeaders = toHeaders(fetchMock.mock.calls[0]?.[1]?.headers);

--- a/packages/providers/claude-code/src/fingerprint/data.json
+++ b/packages/providers/claude-code/src/fingerprint/data.json
@@ -1052,7 +1052,7 @@
     "Write"
   ],
   "anthropic_beta": "claude-code-20250219,oauth-2025-04-20,context-1m-2025-08-07,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,extended-cache-ttl-2025-04-11",
-  "cc_version": "2.1.161",
+  "cc_version": "2.1.169",
   "header_order": [
     "Accept",
     "Authorization",
@@ -1082,7 +1082,7 @@
     "anthropic-dangerous-direct-browser-access": "true",
     "anthropic-version": "2023-06-01",
     "content-type": "application/json",
-    "user-agent": "claude-cli/2.1.161 (external, sdk-cli)",
+    "user-agent": "claude-cli/2.1.169 (external, sdk-cli)",
     "x-app": "cli",
     "x-stainless-timeout": "600"
   },

--- a/packages/providers/claude-code/src/opencode-shared.ts
+++ b/packages/providers/claude-code/src/opencode-shared.ts
@@ -138,6 +138,44 @@ export function composeClaudeCodeBillingSystemEntry(
   return `x-anthropic-billing-header: cc_version=${version}.${buildTag}; cc_entrypoint=sdk-cli; cch=${cch};`;
 }
 
+// Claude Code caches the two system blocks above, plus the tools prefix and
+// one rolling conversation breakpoint. Client-supplied cache_control is stripped
+// before this shared helper runs; these markers are Kyoli-owned outbound hints.
+export function applyClaudeCodePromptCaching(
+  body: Record<string, unknown>,
+  cacheControl: { type: "ephemeral" } = { type: "ephemeral" },
+): void {
+  const tools = body.tools as Array<Record<string, unknown>> | undefined;
+  if (Array.isArray(tools) && tools.length > 0) {
+    const clonedTools = tools.map((tool) => {
+      const cloned = { ...tool };
+      delete cloned.cache_control;
+      return cloned;
+    });
+    clonedTools[clonedTools.length - 1] = {
+      ...clonedTools[clonedTools.length - 1],
+      cache_control: cacheControl,
+    };
+    body.tools = clonedTools;
+  }
+
+  const messages = body.messages as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return;
+  }
+
+  const lastMessage = messages[messages.length - 1];
+  const content = lastMessage?.content;
+  if (!Array.isArray(content) || content.length === 0) {
+    return;
+  }
+
+  content[content.length - 1] = {
+    ...content[content.length - 1],
+    cache_control: cacheControl,
+  };
+}
+
 export function applyClaudeCodeUpstreamBodyFields(
   body: Record<string, unknown>,
   input: ClaudeCodeUpstreamBodyOptions,
@@ -186,6 +224,8 @@ export function applyClaudeCodeUpstreamBodyFields(
   ) {
     body.tools = input.defaultTools.map((tool) => ({ ...tool }));
   }
+
+  applyClaudeCodePromptCaching(body);
 
   return orderClaudeCodeBodyForOutbound(body, input.bodyFieldOrder);
 }

--- a/packages/providers/claude-code/tests/claude-code-provider.test.ts
+++ b/packages/providers/claude-code/tests/claude-code-provider.test.ts
@@ -113,7 +113,43 @@ describe("OpenCode shared Claude Code helpers", () => {
       device_id: "device-1",
       session_id: "session-1",
     });
-    expect(body.tools).toEqual([{ name: "Bash", input_schema: { type: "object" } }]);
+    expect(body.tools).toEqual([
+      {
+        name: "Bash",
+        input_schema: { type: "object" },
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+  });
+
+  it("adds Claude Code prompt cache breakpoints to tools and block-array messages", () => {
+    const body = applyClaudeCodeUpstreamBodyFields(
+      {
+        messages: [
+          { role: "user", content: [{ type: "text", text: "hello" }] },
+          { role: "assistant", content: [{ type: "text", text: "answer" }] },
+        ],
+        tools: [
+          { name: "Read", input_schema: { type: "object" }, cache_control: { type: "ephemeral" } },
+          { name: "Write", input_schema: { type: "object" } },
+        ],
+      },
+      {
+        agentIdentity: "agent identity",
+        ccVersion: "2.1.137",
+        identity: { accountUuid: "account-1", deviceId: "device-1" },
+        sessionId: "session-1",
+        systemPrompt: "system prompt",
+      },
+    );
+
+    const tools = body.tools as Array<{ cache_control?: { type: string } }>;
+    const messages = body.messages as Array<{ content: Array<{ cache_control?: { type: string } }> }>;
+
+    expect(tools[0]?.cache_control).toBeUndefined();
+    expect(tools[1]?.cache_control).toEqual({ type: "ephemeral" });
+    expect(messages[0]?.content[0]?.cache_control).toBeUndefined();
+    expect(messages[1]?.content[0]?.cache_control).toEqual({ type: "ephemeral" });
   });
 });
 


### PR DESCRIPTION
Preserve user-owned Anthropic message and tool-result content while keeping Kyoli's Claude Code identity masking intact. Outbound requests now add Kyoli-owned prompt-cache breakpoints after incoming `cache_control` is stripped, and the bundled Claude Code fallback labels match the 2.1.169 compatibility range.

**Payload-safe scrubbing**

System and identity prose still use the full framework scrubber, but user messages and tool results now use a content-safe subset so code/data tokens like `continue`, `cursor`, `gateway`, `OpenAI`, `Hermes`, and `Powered by Stripe` are preserved.

**Claude Code request fidelity**

The shared Claude Code body helper now marks the last tool and last block-array message with ephemeral prompt cache hints, matching the system prompt cache behavior without re-allowing client-supplied cache controls.

**Fingerprint labels**

Both bundled Claude Code fingerprint copies now report `cc_version` and `user-agent` as 2.1.169, keeping `DEFAULT_CLI_VERSION` aligned with the current max-tested range.
