### PR TITLE
feat(claude-code): Add Fable 5 routing guards

### DIFF
--- a/.changeset/fable-5-exposure.md
+++ b/.changeset/fable-5-exposure.md
@@ -1,0 +1,5 @@
+---
+"opencode-anthropic-multi-account": patch
+---
+
+Add Claude Fable 5 routing guards, aliases, beta tailoring, and wire-model normalization.

--- a/packages/anthropic-multi-account/src/model/config.ts
+++ b/packages/anthropic-multi-account/src/model/config.ts
@@ -1,6 +1,10 @@
 import { claudeCodeIntegration } from "../claude-code";
 import { ANTHROPIC_OAUTH_ADAPTER } from "../shared/constants";
 
+export const FABLE_FALLBACK_CREDIT_BETA = "fallback-credit-2026-06-01";
+export const MID_CONVERSATION_SYSTEM_BETA = "mid-conversation-system-2026-04-07";
+export const EFFORT_BETA = "effort-2025-11-24";
+
 export interface ModelOverride {
   exclude?: string[];
   add?: string[];
@@ -23,8 +27,18 @@ export const config: ModelConfig = {
   baseBetas: splitBetaFlags(ANTHROPIC_OAUTH_ADAPTER.requestBetaHeader),
   longContextBetas: ["context-1m-2025-08-07", "context-management-2025-06-27"],
   modelOverrides: {
+    fable: {
+      add: [FABLE_FALLBACK_CREDIT_BETA],
+    },
+    sonnet: {
+      exclude: [MID_CONVERSATION_SYSTEM_BETA],
+      add: [EFFORT_BETA],
+    },
+    haiku: {
+      exclude: [MID_CONVERSATION_SYSTEM_BETA, EFFORT_BETA],
+    },
     "4-6": {
-      add: ["effort-2025-11-24"],
+      add: [EFFORT_BETA],
     },
   },
 };
@@ -38,7 +52,11 @@ export function getUserAgent(): string {
 }
 
 export function getRequiredBetas(): string[] {
-  return splitBetaFlags(process.env.ANTHROPIC_BETA_FLAGS ?? config.baseBetas.join(","));
+  return splitBetaFlags(
+    process.env.ANTHROPIC_BETA_FLAGS
+      ?? claudeCodeIntegration.loadRequestProfile().betaHeader
+      ?? config.baseBetas.join(","),
+  );
 }
 
 export function getModelOverride(modelId: string): ModelOverride | null {

--- a/packages/anthropic-multi-account/src/request/betas.ts
+++ b/packages/anthropic-multi-account/src/request/betas.ts
@@ -1,3 +1,4 @@
+import { resolveClaudeCodeModelAlias, isClaudeCode1mModelLabel } from "../../../providers/claude-code/src/opencode-shared";
 import { config, getModelOverride, getRequiredBetas } from "../model/config";
 
 export const LONG_CONTEXT_BETAS = config.longContextBetas;
@@ -72,35 +73,40 @@ export function getNextBetaToExclude(modelId: string): string | null {
 }
 
 export function supports1mContext(modelId: string): boolean {
-  const lowerModelId = modelId.toLowerCase();
-  if (!lowerModelId.includes("opus") && !lowerModelId.includes("sonnet")) {
+  const lowerModelId = resolveClaudeCodeModelAlias(modelId).toLowerCase();
+  if (isClaudeCode1mModelLabel(modelId)) {
+    return lowerModelId.includes("fable") || lowerModelId.includes("opus") || lowerModelId.includes("sonnet");
+  }
+
+  if (!lowerModelId.includes("opus") && !lowerModelId.includes("sonnet") && !lowerModelId.includes("fable")) {
     return false;
   }
 
-  const versionMatch = lowerModelId.match(/(opus|sonnet)-(\d+)-(\d+)/);
+  const versionMatch = lowerModelId.match(/(opus|sonnet|fable)-(\d+)(?:-(\d+))?/);
   if (!versionMatch) {
     return false;
   }
 
   const major = Number.parseInt(versionMatch[2]!, 10);
-  const minor = Number.parseInt(versionMatch[3]!, 10);
+  const minor = versionMatch[3] ? Number.parseInt(versionMatch[3], 10) : 0;
   const effectiveMinor = minor > 99 ? 0 : minor;
   return major > 4 || (major === 4 && effectiveMinor >= 6);
 }
 
 export function getModelBetas(modelId: string, excluded?: Set<string>): string[] {
+  const normalizedModelId = resolveClaudeCodeModelAlias(modelId);
   const betas = [...getRequiredBetas()];
   const longContextBeta = config.longContextBetas[0];
 
   if (
     longContextBeta
-    && process.env.ANTHROPIC_ENABLE_1M_CONTEXT === "true"
-    && supports1mContext(modelId)
+    && (process.env.ANTHROPIC_ENABLE_1M_CONTEXT === "true" || isClaudeCode1mModelLabel(normalizedModelId))
+    && supports1mContext(normalizedModelId)
   ) {
     betas.push(longContextBeta);
   }
 
-  const override = getModelOverride(modelId);
+  const override = getModelOverride(normalizedModelId);
   if (override?.exclude) {
     for (const excludedBeta of override.exclude) {
       const index = betas.indexOf(excludedBeta);

--- a/packages/anthropic-multi-account/src/request/transform.ts
+++ b/packages/anthropic-multi-account/src/request/transform.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { resolveClaudeCodeModelAlias } from "../../../providers/claude-code/src/opencode-shared";
 import { ensureOauthBeta, getModelBetas } from "./betas";
 import { claudeCodeIntegration } from "../claude-code";
 import { ANTHROPIC_OAUTH_ADAPTER } from "../shared/constants";
@@ -13,7 +14,6 @@ import {
 } from "../tools/flow";
 import {
   filterBillableBetas,
-  getBetaHeader,
   getPerRequestHeaders,
   getStaticHeaders,
   orderHeadersForOutbound,
@@ -162,7 +162,6 @@ export function buildRequestHeaders(
   const incomingHeaders = getMergedIncomingHeaders(input, init);
   const sessionId = resolveSessionId(incomingHeaders);
   const mergedBetas = dedupeHeaderValues(ensureOauthBeta([
-    ...excludeBetas(splitHeaderValues(getBetaHeader()), excludedBetas),
     ...getModelBetas(modelId, excludedBetas),
     ...excludeBetas(splitHeaderValues(incomingHeaders["anthropic-beta"]), excludedBetas),
   ])).join(",");
@@ -191,7 +190,7 @@ export function extractModelIdFromBody(body: BodyInit | null | undefined): strin
 
   try {
     const parsed = JSON.parse(body) as RequestPayload;
-    return typeof parsed.model === "string" ? parsed.model : "unknown";
+    return typeof parsed.model === "string" ? resolveClaudeCodeModelAlias(parsed.model) : "unknown";
   } catch {
     return "unknown";
   }

--- a/packages/anthropic-multi-account/src/request/upstream-request.ts
+++ b/packages/anthropic-multi-account/src/request/upstream-request.ts
@@ -3,7 +3,10 @@ import {
   applyClaudeCodeUpstreamBodyFields,
   composeClaudeCodeBillingSystemEntry,
   computeClaudeCodeBuildTag,
+  isClaudeFableModel,
   orderClaudeCodeBodyForOutbound,
+  resolveClaudeCodeModelAlias,
+  toClaudeCodeWireModelId,
 } from "../../../providers/claude-code/src/opencode-shared";
 import { claudeCodeIntegration, type ClaudeIdentity, type TemplateData } from "../claude-code";
 import { getRuntimeModelCapability } from "../model/capabilities";
@@ -125,17 +128,24 @@ export function getClientOutputEffort(inputBody: Record<string, unknown>): Outpu
 export function resolveOutputEffort(
   inputBody: Record<string, unknown>,
   configuredEffort = getConfiguredOutputEffort(),
+  modelId?: string,
 ): string {
   if (configuredEffort && configuredEffort !== "client") {
-    return normalizeEffortForWire(configuredEffort);
+    return clampFableEffort(normalizeEffortForWire(configuredEffort), modelId);
   }
 
   const clientEffort = getClientOutputEffort(inputBody);
-  return normalizeEffortForWire(clientEffort ?? DEFAULT_OUTPUT_EFFORT);
+  return clampFableEffort(normalizeEffortForWire(clientEffort ?? DEFAULT_OUTPUT_EFFORT), modelId);
 }
 
 function isHaikuModel(modelId: string): boolean {
-  return modelId.trim().toLowerCase().includes("haiku");
+  return resolveClaudeCodeModelAlias(modelId).toLowerCase().includes("haiku");
+}
+
+function clampFableEffort(effort: string, modelId: string | undefined): string {
+  return modelId && isClaudeFableModel(modelId) && (effort === "max" || effort === "xhigh")
+    ? "high"
+    : effort;
 }
 
 function collectToolUseIds(message: Message): string[] {
@@ -191,6 +201,7 @@ const ADAPTIVE_THINKING_MODEL_MATCHERS = [
   (modelId: string) => modelId.includes("claude-sonnet-4-6") || modelId.includes("claude-sonnet-4.6"),
   (modelId: string) => modelId.includes("claude-opus-4-6") || modelId.includes("claude-opus-4.6"),
   (modelId: string) => /claude-opus-4[-._]([7-9]|\d{2,})/.test(modelId),
+  (modelId: string) => /claude-fable-(?:[5-9]|\d{2,})(?:[-._]\d+)?(?:\[1m\])?$/.test(modelId),
 ];
 const DEFAULT_MAX_OUTPUT_TOKENS = 32_000;
 
@@ -200,7 +211,7 @@ function supportsAdaptiveThinking(modelId: string): boolean {
     return runtimeCapability.supportsThinking;
   }
 
-  const normalized = modelId.trim().toLowerCase();
+  const normalized = resolveClaudeCodeModelAlias(modelId).toLowerCase();
   if (normalized.includes("haiku")) {
     return false;
   }
@@ -310,17 +321,24 @@ export function buildUpstreamRequest(
   const configuredEffort = getConfiguredOutputEffort() ?? options?.outputEffort;
 
   const incomingTools = Array.isArray(body.tools) ? body.tools as ToolDefinition[] : [];
-  body.tools = selectOpenCodeNativeTools({
+  const selectedTools = selectOpenCodeNativeTools({
     incomingTools,
     templateTools: template.tools,
-  }).tools;
-  const modelId = typeof body.model === "string" ? body.model : "";
+  });
+  body.tools = selectedTools.tools;
+  const modelId = typeof body.model === "string" ? resolveClaudeCodeModelAlias(body.model) : "";
+  if (typeof body.model === "string") {
+    body.model = toClaudeCodeWireModelId(body.model);
+  }
+  if (isClaudeFableModel(modelId) && incomingTools.length === 0 && selectedTools.tools.length > 0) {
+    body.tool_choice = { type: "none" };
+  }
   if (supportsAdaptiveThinking(modelId)) {
     body.thinking = { type: "adaptive" };
     body.context_management = DEFAULT_CONTEXT_MANAGEMENT;
   }
   if (modelId && !isHaikuModel(modelId)) {
-    body.output_config = { effort: resolveOutputEffort(inputBody, configuredEffort) };
+    body.output_config = { effort: resolveOutputEffort(inputBody, configuredEffort, modelId) };
   }
   body.max_tokens = resolveMaxTokens(body.max_tokens);
 

--- a/packages/anthropic-multi-account/src/runtime/factory.ts
+++ b/packages/anthropic-multi-account/src/runtime/factory.ts
@@ -20,7 +20,6 @@ import {
 } from "../request/betas";
 import {
   filterBillableBetas,
-  getBetaHeader,
   getPerRequestHeaders,
   getStaticHeaders,
   orderHeadersForOutbound,
@@ -360,7 +359,6 @@ export class AccountRuntimeFactory {
     excludedBetas: Set<string>,
   ): HeadersInit {
     const mergedBetas = deduplicateBetas(ensureOauthBeta([
-      ...excludeBetas(splitBetaValues(getBetaHeader()), excludedBetas),
       ...getModelBetas(modelId, excludedBetas),
       ...excludeBetas(splitBetaValues(incomingHeaders["anthropic-beta"]), excludedBetas),
     ])).join(",");

--- a/packages/anthropic-multi-account/tests/request/transform.test.ts
+++ b/packages/anthropic-multi-account/tests/request/transform.test.ts
@@ -103,6 +103,41 @@ describe("buildRequestHeaders", () => {
     expect(headers.get("x-api-key")).toBe(null);
   });
 
+
+
+  test("applies Fable-specific beta flags and per-family omissions", () => {
+    const fableHeaders = new Headers(buildRequestHeaders(
+      "https://api.anthropic.com/v1/messages",
+      { headers: {} },
+      "token-123",
+      "fable1m",
+    ));
+    const fableBetas = splitBetas(fableHeaders.get("anthropic-beta"));
+
+    expect(fableBetas).toContain("fallback-credit-2026-06-01");
+    expect(fableBetas).toContain("context-1m-2025-08-07");
+
+    const sonnetHeaders = new Headers(buildRequestHeaders(
+      "https://api.anthropic.com/v1/messages",
+      { headers: {} },
+      "token-123",
+      "claude-sonnet-4-6",
+    ));
+    const sonnetBetas = splitBetas(sonnetHeaders.get("anthropic-beta"));
+    expect(sonnetBetas).not.toContain("mid-conversation-system-2026-04-07");
+    expect(sonnetBetas).toContain("effort-2025-11-24");
+
+    const haikuHeaders = new Headers(buildRequestHeaders(
+      "https://api.anthropic.com/v1/messages",
+      { headers: {} },
+      "token-123",
+      "claude-haiku-4-5",
+    ));
+    const haikuBetas = splitBetas(haikuHeaders.get("anthropic-beta"));
+    expect(haikuBetas).not.toContain("mid-conversation-system-2026-04-07");
+    expect(haikuBetas).not.toContain("effort-2025-11-24");
+  });
+
   test("can enable 1m beta through environment variable", () => {
     process.env.ANTHROPIC_ENABLE_1M_CONTEXT = "true";
     try {
@@ -124,6 +159,7 @@ describe("buildRequestHeaders", () => {
 describe("extractModelIdFromBody", () => {
   test("returns model id when present in JSON body", () => {
     expect(extractModelIdFromBody(JSON.stringify({ model: "claude-sonnet-4-6" }))).toBe("claude-sonnet-4-6");
+    expect(extractModelIdFromBody(JSON.stringify({ model: "anthropic/fable1m" }))).toBe("claude-fable-5[1m]");
   });
 
   test("returns unknown for invalid JSON or missing model", () => {

--- a/packages/anthropic-multi-account/tests/request/upstream-request.test.ts
+++ b/packages/anthropic-multi-account/tests/request/upstream-request.test.ts
@@ -432,6 +432,30 @@ describe("upstream-request", () => {
     expect(result.output_config).toEqual({ effort: "xhigh" });
   });
 
+
+
+  test("buildUpstreamRequest maps Fable aliases to CC wire shape", () => {
+    const result = buildUpstreamRequest({
+      model: "fable1m",
+      output_config: { effort: "max" },
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: [{ type: "text", text: "answer" }] },
+        { role: "user", content: "again" },
+      ],
+    }, createIdentity(), createTemplate());
+
+    expect(result.model).toBe("claude-fable-5");
+    expect(result.thinking).toEqual({ type: "adaptive" });
+    expect(result.context_management).toEqual({});
+    expect(result.output_config).toEqual({ effort: "high" });
+    expect(result.tool_choice).toEqual({ type: "none" });
+    expect(result.tools).toEqual([
+      { name: "Bash", description: "Run shell commands", input_schema: { type: "object" } },
+      { name: "Read", description: "Read files", input_schema: { type: "object" }, cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
   test("buildUpstreamRequest emits output_config for non-adaptive non-Haiku models", () => {
     const result = buildUpstreamRequest({
       model: "claude-sonnet-4-5",

--- a/packages/gateway/src/codex-claude-bridge.ts
+++ b/packages/gateway/src/codex-claude-bridge.ts
@@ -110,8 +110,10 @@ export function toCodexClaudeModelEntry(model: ModelInfo): Record<string, unknow
 }
 
 function isCodexClaudeBridgeCandidate(upstreamId: string): boolean {
-  return /^claude-(sonnet|opus|haiku)-4(?:-\d+)*$/.test(upstreamId) &&
-    !/-\d{8}$/.test(upstreamId);
+  return (
+    /^claude-(sonnet|opus|haiku)-4(?:-\d+)*$/.test(upstreamId)
+    || /^claude-fable-5(?:\[1m\])?$/.test(upstreamId)
+  ) && !/-\d{8}$/.test(upstreamId);
 }
 
 export async function handleCodexClaudeBridgeRequest(

--- a/packages/model-registry/src/bundled-snapshot.ts
+++ b/packages/model-registry/src/bundled-snapshot.ts
@@ -15,6 +15,13 @@ export const bundledModelsDevSnapshot = {
     id: "anthropic",
     name: "Anthropic",
     models: {
+      "claude-fable-5": {
+        id: "claude-fable-5",
+        name: "Claude Fable 5",
+        reasoning: true,
+        tool_call: true,
+        limit: { context: 1000000, output: 128000 },
+      },
       "claude-sonnet-4-5": {
         id: "claude-sonnet-4-5",
         name: "Claude Sonnet 4.5",

--- a/packages/model-registry/src/models-dev.ts
+++ b/packages/model-registry/src/models-dev.ts
@@ -162,18 +162,37 @@ function mapProviderModels(
 ): ModelInfo[] {
   const kyoliProvider = toKyoliProviderId(providerId);
   const publicProvider = toPublicProviderId(providerId);
-  return Object.entries(models).map(([modelId, model]) => ({
-    id: `${publicProvider}/${modelId}`,
-    provider: kyoliProvider,
-    upstreamId: model.id ?? modelId,
-    displayName: model.name ?? modelId,
-    aliases: [
-      model.id ?? modelId,
-      `${kyoliProvider}/${model.id ?? modelId}`,
-    ],
-    capabilities: inferCapabilities(providerId, model),
-    metadata: pickModelMetadata(model),
-  }));
+  return Object.entries(models).map(([modelId, model]) => {
+    const upstreamId = model.id ?? modelId;
+    return {
+      id: `${publicProvider}/${modelId}`,
+      provider: kyoliProvider,
+      upstreamId,
+      displayName: model.name ?? modelId,
+      aliases: buildModelAliases(providerId, upstreamId),
+      capabilities: inferCapabilities(providerId, model),
+      metadata: pickModelMetadata(model),
+    };
+  });
+}
+
+function buildModelAliases(providerId: ModelsDevProviderId, upstreamId: string): string[] {
+  const kyoliProvider = toKyoliProviderId(providerId);
+  const publicProvider = toPublicProviderId(providerId);
+  const aliases = [
+    upstreamId,
+    `${kyoliProvider}/${upstreamId}`,
+  ];
+
+  if (providerId === "anthropic" && upstreamId === "claude-fable-5") {
+    aliases.push(
+      "fable",
+      `${kyoliProvider}/fable`,
+      `${publicProvider}/fable`,
+    );
+  }
+
+  return [...new Set(aliases)];
 }
 
 function pickModelMetadata(model: ModelsDevModel): Record<string, unknown> | undefined {

--- a/packages/model-registry/tests/model-registry.test.ts
+++ b/packages/model-registry/tests/model-registry.test.ts
@@ -62,6 +62,49 @@ describe("ModelRegistry", () => {
     });
   });
 
+  it("adds Fable aliases from models.dev for Claude Code routing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kyoli-fable-models-dev-"));
+    const localPath = join(dir, "api.json");
+    await writeFile(localPath, JSON.stringify({
+      anthropic: {
+        models: {
+          "claude-fable-5": {
+            id: "claude-fable-5",
+            name: "Claude Fable 5",
+            reasoning: true,
+            tool_call: true,
+          },
+        },
+      },
+    }));
+    const registry = new ModelRegistry([
+      adapter("claude-code", "anthropic/claude-fable-5[1m]", "claude-fable-5[1m]", ["fable1m", "claude-fable-5[1m]"]),
+    ], {
+      modelsDev: new ModelsDevRegistrySource({
+        sourceUrl: "https://models.dev",
+        cachePath: join(dir, "cache.json"),
+        localPath,
+        disableFetch: true,
+        refreshIntervalMs: 60_000,
+        fetchTimeoutMs: 10_000,
+      }),
+    });
+
+    await expect(registry.resolve("fable")).resolves.toMatchObject({
+      provider: "claude-code",
+      upstreamId: "claude-fable-5",
+    });
+    await expect(registry.resolve("fable1m")).resolves.toMatchObject({
+      provider: "claude-code",
+      upstreamId: "claude-fable-5[1m]",
+    });
+    await expect(registry.listModels()).resolves.toContainEqual(expect.objectContaining({
+      id: "anthropic/claude-fable-5",
+      aliases: expect.arrayContaining(["fable", "claude-code/fable", "anthropic/fable"]),
+      capabilities: expect.arrayContaining(["messages", "reasoning", "tools"]),
+    }));
+  });
+
   it("marks OpenAI models.dev Codex-family models as Codex-capable", async () => {
     const dir = await mkdtemp(join(tmpdir(), "kyoli-models-dev-"));
     const localPath = join(dir, "api.json");

--- a/packages/providers/claude-code/src/index.ts
+++ b/packages/providers/claude-code/src/index.ts
@@ -18,6 +18,12 @@ import {
 } from "@kyoli-gam/core";
 import {
   applyClaudeCodeUpstreamBodyFields,
+  CLAUDE_FABLE_1M_MODEL_ID,
+  CLAUDE_FABLE_MODEL_ID,
+  isClaudeCode1mModelLabel,
+  isClaudeFableModel,
+  resolveClaudeCodeModelAlias,
+  toClaudeCodeWireModelId,
 } from "./opencode-shared";
 import {
   refreshClaudeCodeAccountMetadata,
@@ -61,6 +67,9 @@ const TOKEN_EXPIRY_BUFFER_MS = 60_000;
 const BILLABLE_BETA_PREFIXES = ["extended-cache-ttl-"];
 const CONTEXT_1M_BETA = "context-1m-2025-08-07";
 const CONTEXT_MANAGEMENT_BETA = "context-management-2025-06-27";
+const FABLE_FALLBACK_CREDIT_BETA = "fallback-credit-2026-06-01";
+const MID_CONVERSATION_SYSTEM_BETA = "mid-conversation-system-2026-04-07";
+const EFFORT_BETA = "effort-2025-11-24";
 const LONG_CONTEXT_BETAS = [CONTEXT_1M_BETA, CONTEXT_MANAGEMENT_BETA] as const;
 const BILLING_SEED = "59cf53e54c78";
 const CLAUDE_STARTUP_PROBE_MAX_BYTES = 64 * 1024;
@@ -72,6 +81,34 @@ const sessionIdsByKey = new Map<string, ClaudeSessionState>();
 const fallbackDeviceId = randomUUID();
 
 const models: ModelInfo[] = [
+  {
+    id: `anthropic/${CLAUDE_FABLE_MODEL_ID}`,
+    provider: "claude-code",
+    upstreamId: CLAUDE_FABLE_MODEL_ID,
+    displayName: "Claude Fable 5 via Claude Code",
+    aliases: [
+      CLAUDE_FABLE_MODEL_ID,
+      "fable",
+      `claude-code/${CLAUDE_FABLE_MODEL_ID}`,
+      "claude-code/fable",
+    ],
+    capabilities: ["messages", "tools", "streaming", "reasoning", "claude-code"],
+    metadata: { max_context_window: 1_000_000 },
+  },
+  {
+    id: `anthropic/${CLAUDE_FABLE_1M_MODEL_ID}`,
+    provider: "claude-code",
+    upstreamId: CLAUDE_FABLE_1M_MODEL_ID,
+    displayName: "Claude Fable 5 [1m] via Claude Code",
+    aliases: [
+      CLAUDE_FABLE_1M_MODEL_ID,
+      "fable1m",
+      `claude-code/${CLAUDE_FABLE_1M_MODEL_ID}`,
+      "claude-code/fable1m",
+    ],
+    capabilities: ["messages", "tools", "streaming", "reasoning", "claude-code"],
+    metadata: { max_context_window: 1_000_000 },
+  },
   {
     id: "anthropic/claude-sonnet-4-5",
     provider: "claude-code",
@@ -278,6 +315,7 @@ export function createClaudeCodeProvider(
           const sessionId = getClaudeSessionId(context.sessionKey, sessionRotation);
           const transformed = transformRequestBody(context.body, {
             identity: resolveRequestIdentity(claudeCredential, options.identity),
+            model: context.model,
             route: context.route,
             sessionKey: context.sessionKey,
             sessionId,
@@ -892,6 +930,7 @@ function transformRequestBody(
   body: unknown,
   options: {
     identity: Required<ClaudeCodeIdentity>;
+    model?: string;
     route: string;
     sessionKey: string;
     sessionId: string;
@@ -906,10 +945,12 @@ function transformRequestBody(
   }
 
   let record = { ...(body as Record<string, unknown>) };
+  const requestModel = readString(record.model) ?? options.model;
   if (typeof record.model === "string") {
-    record.model = stripProviderPrefix(record.model);
+    record.model = toClaudeCodeWireModelId(record.model);
   }
 
+  const hadIncomingTools = Array.isArray(record.tools) && record.tools.length > 0;
   stripCacheControl(record);
   removeUnsupportedClaudeCodeFields(record);
   if (options.route === "/v1/messages") {
@@ -926,6 +967,9 @@ function transformRequestBody(
       sessionId: options.sessionId,
       systemPrompt: CLAUDE_CODE_SYSTEM_PROMPT,
     });
+    if (requestModel && isClaudeFableModel(requestModel) && !hadIncomingTools && Array.isArray(record.tools) && record.tools.length > 0) {
+      record.tool_choice = { type: "none" };
+    }
   }
 
   const transformed = applyClaudeToolFlow(record);
@@ -974,7 +1018,7 @@ function buildUpstreamHeaders(input: {
     "anthropic-beta",
     mergeBetaHeaders(
       input.trustClientFingerprint ? headers.get("anthropic-beta") : null,
-      fingerprint.anthropicBeta,
+      getClaudeCodeBetasForModel(fingerprint.anthropicBeta, input.model, input.excludedBetas),
       input.excludedBetas,
     ),
   );
@@ -1275,6 +1319,41 @@ function removeUnsupportedClaudeCodeFields(body: Record<string, unknown>): void 
   delete body.temperature;
   delete body.top_p;
   delete body.top_k;
+}
+
+function splitBetaHeader(value: string): string[] {
+  return value.split(",").map((entry) => entry.trim()).filter(Boolean);
+}
+
+function getClaudeCodeBetasForModel(
+  defaults: string,
+  model: string | undefined,
+  excludedBetas: Set<string> = new Set(),
+): string {
+  const normalizedModel = model ? resolveClaudeCodeModelAlias(model).toLowerCase() : "";
+  const values = splitBetaHeader(defaults);
+  const add = (beta: string): void => {
+    if (!excludedBetas.has(beta) && !values.includes(beta)) values.push(beta);
+  };
+  const drop = (beta: string): void => {
+    const index = values.indexOf(beta);
+    if (index !== -1) values.splice(index, 1);
+  };
+
+  if (model && isClaudeFableModel(model)) {
+    add(FABLE_FALLBACK_CREDIT_BETA);
+  }
+  if (model && isClaudeCode1mModelLabel(model)) {
+    add(CONTEXT_1M_BETA);
+  }
+  if (normalizedModel.includes("haiku")) {
+    drop(MID_CONVERSATION_SYSTEM_BETA);
+    drop(EFFORT_BETA);
+  } else if (normalizedModel.includes("sonnet")) {
+    drop(MID_CONVERSATION_SYSTEM_BETA);
+  }
+
+  return values.filter((beta) => !excludedBetas.has(beta)).join(",");
 }
 
 function mergeBetaHeaders(

--- a/packages/providers/claude-code/src/opencode-shared.ts
+++ b/packages/providers/claude-code/src/opencode-shared.ts
@@ -10,6 +10,45 @@ const templateMetadata = getClaudeCodeTemplateMetadata();
 const templateHeaders = templateMetadata.headerValues;
 const CLAUDE_CODE_VERSION = templateMetadata.ccVersion ?? "2.1.137";
 
+export const CLAUDE_FABLE_MODEL_ID = "claude-fable-5";
+export const CLAUDE_FABLE_1M_MODEL_ID = `${CLAUDE_FABLE_MODEL_ID}[1m]`;
+
+const CLAUDE_CODE_MODEL_ALIASES: Record<string, string> = {
+  fable: CLAUDE_FABLE_MODEL_ID,
+  fable1m: CLAUDE_FABLE_1M_MODEL_ID,
+};
+
+export function stripClaudeCodeProviderPrefix(modelId: string): string {
+  const slash = modelId.indexOf("/");
+  if (slash === -1) return modelId;
+
+  const provider = modelId.slice(0, slash).toLowerCase();
+  return provider === "anthropic" || provider === "claude-code"
+    ? modelId.slice(slash + 1)
+    : modelId;
+}
+
+export function resolveClaudeCodeModelAlias(modelId: string): string {
+  const unprefixed = stripClaudeCodeProviderPrefix(modelId.trim());
+  return CLAUDE_CODE_MODEL_ALIASES[unprefixed.toLowerCase()] ?? unprefixed;
+}
+
+export function stripClaudeCodeContext1mTag(modelId: string): string {
+  return modelId.replace(/\[1m\]$/i, "");
+}
+
+export function toClaudeCodeWireModelId(modelId: string): string {
+  return stripClaudeCodeContext1mTag(resolveClaudeCodeModelAlias(modelId));
+}
+
+export function isClaudeCode1mModelLabel(modelId: string): boolean {
+  return /\[1m\]$/i.test(resolveClaudeCodeModelAlias(modelId));
+}
+
+export function isClaudeFableModel(modelId: string): boolean {
+  return resolveClaudeCodeModelAlias(modelId).toLowerCase().includes("fable");
+}
+
 export interface ClaudeCodeSharedRequestProfile {
   anthropicBeta: string;
   anthropicVersion: string;

--- a/packages/providers/claude-code/tests/claude-code-provider.test.ts
+++ b/packages/providers/claude-code/tests/claude-code-provider.test.ts
@@ -306,6 +306,67 @@ describe("createClaudeCodeProvider", () => {
     expect(userId.session_id).toBe(upstreamSessionId);
   });
 
+
+
+  it("routes Fable aliases with fallback beta and safe tool defaults", async () => {
+    let upstreamBody: Record<string, unknown> = {};
+    let upstreamBeta = "";
+
+    const store = new MemoryAccountStore();
+    await store.create({
+      provider: "claude-code",
+      kind: "oauth",
+      credentials: {
+        accessToken: "access-test",
+        expiresAt: Date.now() + 60 * 60 * 1000,
+        refreshToken: "refresh-test",
+      },
+    });
+
+    const provider = createTestClaudeCodeProvider({
+      accounts: new StickyAccountPool(store),
+      baseUrl: "https://example.test",
+      usageRefresh: async () => ({ cachedUsageAt: Date.now() }),
+      fetch: async (_input, init) => {
+        const headers = new Headers(init?.headers);
+        upstreamBeta = headers.get("anthropic-beta") ?? "";
+        upstreamBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+
+        return new Response(JSON.stringify({ id: "msg_test", type: "message" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+
+    const response = await provider.handleRequest({
+      request: new Request("http://127.0.0.1:2021/v1/messages", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "fable1m",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      }),
+      route: "/v1/messages",
+      sessionKey: "session-fable",
+      body: {
+        model: "fable1m",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hello" }],
+      },
+      model: "fable1m",
+    });
+
+    expect(response.status).toBe(200);
+    expect(upstreamBody.model).toBe("claude-fable-5");
+    expect(upstreamBody.tool_choice).toEqual({ type: "none" });
+    expect((upstreamBody.tools as unknown[]).length).toBeGreaterThan(0);
+    expect(upstreamBeta).toContain("fallback-credit-2026-06-01");
+    expect(upstreamBeta).toContain("context-1m-2025-08-07");
+  });
+
   it("uses Claude Code identity device id while keeping the selected account UUID", async () => {
     let upstreamBody: {
       metadata?: {


### PR DESCRIPTION
## Summary
- expose Claude Fable 5 and Fable 5 [1m] in the Claude Code provider/model registry path
- normalize `fable`, `fable1m`, `claude-fable-5[1m]`, and provider-prefixed aliases before routing
- tailor per-model beta headers: Fable fallback credit, [1m] context beta, Sonnet/Haiku/Fable omissions
- strip `[1m]` from the upstream wire model, allow Fable adaptive thinking, clamp max Fable effort to `high`, and make tool-less Fable template injection use `tool_choice: none`

## Version / release checklist
- [x] Patch changeset included for `opencode-anthropic-multi-account`
- [x] `pnpm changeset status --since=origin/main` confirms patch bumps for public packages
- [x] No draft PR
- [x] Autoreview completed before PR
- [ ] Wait for all PR checks and review bots before merging or pushing review fixes
- [ ] After merge, confirm Changesets release PR and npm publish

## Validation
- `pnpm --filter @kyoli-gam/model-registry exec vitest run tests/model-registry.test.ts`
- `pnpm --filter opencode-anthropic-multi-account exec vitest run tests/request/transform.test.ts tests/request/upstream-request.test.ts`
- `pnpm --filter @kyoli-gam/provider-claude-code exec vitest run tests/claude-code-provider.test.ts`
- `pnpm typecheck && pnpm test && pnpm build`
- `/Users/yuka/.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "pnpm typecheck && pnpm test && pnpm build"`
- `pnpm changeset status --since=origin/main`
